### PR TITLE
Update calibrations for new transformer structure

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,10 +1,11 @@
 '''
 This module contains the configuration classes for the project.
 '''
+import dataclasses
+import json
 import os
 import uuid
 from dataclasses import dataclass
-from typing import Optional
 
 import gymnasium as gym
 
@@ -143,6 +144,11 @@ class RunConfig:
     track: bool = True
     wandb_project_name: str = "PPO-MiniGrid"
     wandb_entity: str = None
+
+
+class ConfigJsonEncoder(json.JSONEncoder):
+    def default(self, config):
+        return dataclasses.asdict(config)
 
 
 def parse_metadata_to_environment_config(metadata: dict):

--- a/src/decision_transformer/runner.py
+++ b/src/decision_transformer/runner.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 import warnings
@@ -7,7 +8,7 @@ import torch as t
 
 import wandb
 from src.config import (EnvironmentConfig, OfflineTrainConfig, RunConfig,
-                        TransformerModelConfig)
+                        TransformerModelConfig, ConfigJsonEncoder)
 from src.models.trajectory_model import CloneTransformer, DecisionTransformer
 
 # from .model import DecisionTransformer
@@ -125,7 +126,11 @@ def run_decision_transformer(
             os.mkdir("models")
 
         model_path = f"models/{run_name}.pt"
-        t.save(model.state_dict(), model_path)
+        t.save({
+            "model_state_dict": model.state_dict(),
+            "transformer_config": json.dumps(transformer_config, cls=ConfigJsonEncoder),
+            "offline_config": json.dumps(offline_config, cls=ConfigJsonEncoder),
+        }, model_path)
         artifact = wandb.Artifact(run_name, type="model")
         artifact.add_file(model_path)
         wandb.log_artifact(artifact)

--- a/src/decision_transformer/utils.py
+++ b/src/decision_transformer/utils.py
@@ -1,16 +1,12 @@
-
 from dataclasses import dataclass, field
 import argparse
-import torch as t
 import re
 from typing import List
 from .model import DecisionTransformer as DecisionTransformerLegacy
 
-from src.environments.wrappers import RenderResizeWrapper, ViewSizeWrapper
-from minigrid.wrappers import FullyObsWrapper, OneHotPartialObsWrapper, RGBImgPartialObsWrapper
-
 from src.models.trajectory_model import DecisionTransformer
-from src.config import EnvironmentConfig, TransformerModelConfig, RunConfig, OfflineTrainConfig
+from src.config import EnvironmentConfig
+from ..utils import load_model_data
 
 
 @dataclass
@@ -77,7 +73,7 @@ def parse_args():
                         help='<Required> Set flag', required=False, default=[0, 1])
     parser.add_argument("--prob_go_from_end", type=float, default=0.1)
     parser.add_argument("--eval_max_time_steps", type=int, default=1000)
-    parser.add_argument("--cuda", type=bool, default=True)
+    parser.add_argument("--cuda", type=bool, default=False)
     parser.add_argument("--model_type", type=str,
                         default="decision_transformer")
     args = parser.parse_args()
@@ -85,53 +81,22 @@ def parse_args():
 
 
 def load_decision_transformer(model_path, env):
+    state_dict, trajectory_data_set, transformer_config, _ = load_model_data(model_path)
 
-    state_dict = t.load(model_path)
     if "state_encoder.weight" in state_dict.keys():
-        return load_legacy_decision_transformer(model_path, env)
-
-    # get number of layers from the state dict
-    num_layers = max([int(re.findall(r'\d+', k)[0])
-                      for k in state_dict.keys() if "transformer.blocks" in k]) + 1
-    d_model = state_dict['reward_embedding.0.weight'].shape[0]
-    d_mlp = state_dict['transformer.blocks.0.mlp.W_out'].shape[0]
-    n_heads = state_dict['transformer.blocks.0.attn.W_O'].shape[0]
-    max_timestep = state_dict['time_embedding.weight'].shape[0] - 1
-    n_ctx = state_dict['transformer.pos_embed.W_pos'].shape[0]
-    layer_norm = 'transformer.blocks.0.ln1.w' in state_dict
-
-    if 'state_encoder.weight' in state_dict:
-        # otherwise it would be a sequential and wouldn't have this
-        state_embedding_type = 'grid'
-
-    if state_dict['time_embedding.weight'].shape[1] == 1:
-        time_embedding_type = "linear"
-    else:
-        time_embedding_type = "embedding"
+        return load_legacy_decision_transformer(state_dict, env)
 
     # now we can create the model
     # model = DecisionTransformer(
     #     EnvironmentConfig(env.__spec__),
     # )
     environment_config = EnvironmentConfig(
-        env_id=env.unwrapped.spec.id,
-        one_hot_obs=isinstance(env.observation_space, OneHotPartialObsWrapper),
-        img_obs=isinstance(env.observation_space, RGBImgPartialObsWrapper),
-        view_size=env.unwrapped.observation_space["image"].shape[0],
+        env_id=trajectory_data_set.metadata['args']['env_id'],
+        one_hot_obs=trajectory_data_set.observation_type == "one_hot",
+        view_size=trajectory_data_set.metadata['args']['view_size'],
         fully_observed=False,
         capture_video=False,
         render_mode='rgb_array')
-
-    transformer_config = TransformerModelConfig(
-        d_model=d_model,
-        n_heads=n_heads,
-        d_mlp=d_mlp,
-        n_layers=num_layers,
-        n_ctx=n_ctx,
-        layer_norm=layer_norm,
-        time_embedding_type=time_embedding_type,
-        state_embedding_type=state_embedding_type,
-    )
 
     model = DecisionTransformer(
         environment_config=environment_config,
@@ -144,9 +109,7 @@ def load_decision_transformer(model_path, env):
 # To maintain backwards compatibility with the old models.
 
 
-def load_legacy_decision_transformer(model_path, env):
-
-    state_dict = t.load(model_path)
+def load_legacy_decision_transformer(state_dict, env):
 
     # get number of layers from the state dict
     num_layers = max([int(re.findall(r'\d+', k)[0])

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,10 +1,11 @@
 import gzip
+import json
 import lzma
 import os
 import pickle
 import time
 import dataclasses
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from typing import Dict
 
 import numpy as np
@@ -12,6 +13,9 @@ import torch as t
 from typeguard import typechecked
 
 import wandb
+
+from src.config import TransformerModelConfig, OfflineTrainConfig
+from src.decision_transformer.offline_dataset import TrajectoryDataset
 
 
 class TrajectoryWriter():
@@ -150,3 +154,21 @@ def pad_tensor(tensor, length=100, ignore_first_dim=True, pad_token=0, pad_left=
                 tensor = t.cat([tensor, pad], dim=0)
 
         return tensor
+
+
+def load_model_data(model_path):
+    model_info = t.load(model_path)
+    state_dict = model_info["model_state_dict"]
+    transformer_config = TransformerModelConfig(**json.loads(model_info["transformer_config"]))
+    offline_config = OfflineTrainConfig(**json.loads(model_info["offline_config"]))
+
+    trajectory_data_set = TrajectoryDataset(
+        trajectory_path=offline_config.trajectory_path,
+        max_len=transformer_config.n_ctx // 3,
+        pct_traj=offline_config.pct_traj,
+        prob_go_from_end=offline_config.prob_go_from_end,
+        device=transformer_config.device,
+    )
+
+    return state_dict, trajectory_data_set, transformer_config, offline_config
+

--- a/tests/acceptance/test_model_saving_and_loading.py
+++ b/tests/acceptance/test_model_saving_and_loading.py
@@ -1,0 +1,93 @@
+import json
+import os
+import pytest
+import torch
+
+from src.config import EnvironmentConfig, ConfigJsonEncoder, TransformerModelConfig, OfflineTrainConfig
+from src.decision_transformer.offline_dataset import TrajectoryDataset
+from src.models.trajectory_model import DecisionTransformer
+from src.utils import load_model_data
+
+
+@pytest.fixture()
+def cleanup_test_results() -> None:
+    yield
+    os.remove('models/model_data.pt')
+
+
+def test_load_model_data(cleanup_test_results):
+    transformer_config = TransformerModelConfig(
+        d_model=128,
+        n_heads=4,
+        d_mlp=256,
+        n_layers=2,
+        n_ctx=3,
+        layer_norm=False,
+        state_embedding_type='grid',
+        time_embedding_type='embedding',
+        seed=1,
+        device='cpu'
+    )
+
+    offline_config = OfflineTrainConfig(
+        trajectory_path='trajectories/MiniGrid-DoorKey-8x8-trajectories.pkl',
+        batch_size=128,
+        lr=0.0001,
+        weight_decay=0.0,
+        pct_traj=1.0,
+        prob_go_from_end=0.0,
+        device='cpu',
+        track=False,
+        train_epochs=100,
+        test_epochs=10,
+        test_frequency=10,
+        eval_frequency=10,
+        eval_episodes=10,
+        model_type='decision_transformer',
+        initial_rtg=[0.0, 1.0],
+        eval_max_time_steps=100
+    )
+
+    trajectory_data_set = TrajectoryDataset(
+        trajectory_path=offline_config.trajectory_path,
+        max_len=transformer_config.n_ctx // 3,
+        pct_traj=offline_config.pct_traj,
+        prob_go_from_end=offline_config.prob_go_from_end,
+        device=transformer_config.device,
+    )
+
+    environment_config = EnvironmentConfig(
+        env_id=trajectory_data_set.metadata['args']['env_id'],
+        one_hot_obs=trajectory_data_set.observation_type == "one_hot",
+        view_size=trajectory_data_set.metadata['args']['view_size'],
+        fully_observed=False,
+        capture_video=False,
+        render_mode='rgb_array')
+
+    model = DecisionTransformer(
+        environment_config=environment_config,
+        transformer_config=transformer_config
+    )
+
+    torch.save({
+        "model_state_dict": model.state_dict(),
+        "transformer_config": json.dumps(transformer_config, cls=ConfigJsonEncoder),
+        "offline_config": json.dumps(offline_config, cls=ConfigJsonEncoder),
+    }, "models/model_data.pt")
+
+    state_dict, _, loaded_transformer_config, loaded_offline_config = \
+        load_model_data("models/model_data.pt")
+
+    assert_state_dicts_are_equal(state_dict, model.state_dict())
+    assert loaded_transformer_config == transformer_config
+    assert loaded_offline_config == offline_config
+
+
+def assert_state_dicts_are_equal(dict1, dict2):
+    keys1 = sorted(dict1.keys())
+    keys2 = sorted(dict2.keys())
+
+    assert keys1 == keys2
+
+    for key1, key2 in zip(keys1, keys2):
+        assert dict1[key1].equal(dict2[key2])


### PR DESCRIPTION
run_calibrations.py was still expecting the transformer model to have the structure of an older implementation.
To add support for the current and keep support for the legacy implementation, config data is now stored together with the weights when runner.py saves a model. Now run_calibrations.py loads the config instead of reverse engineering it from the weights, which lets the logic to be agnostic regarding the structure of the transformer.

Also added a test for the new storing and loading functionality.