### PR TITLE
Added black formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,7 @@ repos:
     rev: v1.5.4
     hooks:
     -   id: autopep8
+-   repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+    -   id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 79
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+)/
+'''


### PR DESCRIPTION
Added black formatter to .pre-commit-config.yaml and created pyproject.toml with default settings.

This is in response to this issue:
https://github.com/jbloomAus/DecisionTransformerInterpretability/issues/10