### PR TITLE
Store checkpoints on wandb during offline training

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -160,6 +160,7 @@ class OfflineTrainConfig:
     initial_rtg: list[float] = (0.0, 1.0)
     eval_max_time_steps: int = 100
     eval_num_envs: int = 8
+    num_checkpoints: int = 10
 
     def __post_init__(self):
         assert self.model_type in ["decision_transformer", "clone_transformer"]

--- a/src/decision_transformer/runner.py
+++ b/src/decision_transformer/runner.py
@@ -1,4 +1,3 @@
-import json
 import os
 import time
 import warnings
@@ -8,7 +7,6 @@ import torch as t
 
 import wandb
 from src.config import (
-    ConfigJsonEncoder,
     EnvironmentConfig,
     OfflineTrainConfig,
     RunConfig,
@@ -27,7 +25,7 @@ from .offline_dataset import (
     one_hot_encode_observation,
 )
 from .train import train
-from .utils import get_max_len_from_model_type
+from .utils import get_max_len_from_model_type, store_transformer_model
 
 
 def run_decision_transformer(
@@ -154,6 +152,8 @@ def run_decision_transformer(
         initial_rtg=offline_config.initial_rtg,
         eval_max_time_steps=offline_config.eval_max_time_steps,
         eval_num_envs=offline_config.eval_num_envs,
+        exp_name=run_config.exp_name,
+        offline_config=offline_config,
     )
 
     if run_config.track:
@@ -177,21 +177,3 @@ def run_decision_transformer(
         os.remove(model_path)
 
         wandb.finish()
-
-
-def store_transformer_model(path, model, offline_config):
-    t.save(
-        {
-            "model_state_dict": model.state_dict(),
-            "offline_config": json.dumps(
-                offline_config, cls=ConfigJsonEncoder
-            ),
-            "environment_config": json.dumps(
-                model.environment_config, cls=ConfigJsonEncoder
-            ),
-            "model_config": json.dumps(
-                model.transformer_config, cls=ConfigJsonEncoder
-            ),
-        },
-        path,
-    )

--- a/src/run_decision_transformer.py
+++ b/src/run_decision_transformer.py
@@ -54,7 +54,8 @@ if __name__ == "__main__":
         eval_max_time_steps=args.eval_max_time_steps,
         track=args.track,
         convert_to_one_hot=args.convert_to_one_hot,
-        device=run_config.device
+        device=run_config.device,
+        num_checkpoints=args.num_checkpoints,
     )
 
     run_decision_transformer(

--- a/tests/end_end/test_calibration.py
+++ b/tests/end_end/test_calibration.py
@@ -10,7 +10,7 @@ from src.config import (
 )
 
 from src.models.trajectory_transformer import DecisionTransformer
-from src.decision_transformer.runner import store_transformer_model
+from src.decision_transformer.utils import store_transformer_model
 
 
 @pytest.fixture()

--- a/tests/unit/test_streamlit_environment.py
+++ b/tests/unit/test_streamlit_environment.py
@@ -10,7 +10,7 @@ from src.config import (
 )
 from src.models.trajectory_transformer import DecisionTransformer
 
-from src.decision_transformer.runner import store_transformer_model
+from src.decision_transformer.utils import store_transformer_model
 from src.streamlit_app.environment import get_env_and_dt
 from src.environments.registration import register_envs
 


### PR DESCRIPTION
Closes #39 

Similar to how storing of PPO checkpoints works, the number of checkpoints can be set using a command line argument.