### PR TITLE
Improved dockerfile and added dockerignore to speed up Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore large folders that are not needed for Docker context. Speeds up Docker build significantly.
+dti/
+trajectories/
+wandb/

--- a/dockerfile
+++ b/dockerfile
@@ -1,14 +1,11 @@
 FROM pytorch/pytorch:1.13.0-cuda11.6-cudnn8-runtime
 
 # Install dependencies from requirements.txt
-# COPY requirements.txt .
-# RUN pip install -r requirements.txt
+COPY requirements.txt .
+RUN apt-get update && apt-get install -y git && pip install -r requirements.txt
 
 # Copy the rest of the code
 COPY . /home
 
 # Set the working directory to /app
 WORKDIR /home
-
-# install requirements
-RUN apt-get update && apt-get install -y git && pip install -r requirements.txt


### PR DESCRIPTION
Improved Dockerfile build from 21 minutes uncached to 25 seconds cached! Saves a whole bunch of time even uncached since the build context is so much lower. Checked on unit tests which passed just fine, tried adding one and deleting one and the rebuild worked fine.