### PR TITLE
Improved dockerfile and added trajectory collection code to evaluate_dt_agent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore large folders that are not needed for Docker context. Speeds up Docker build significantly.
+dti/
+trajectories/
+wandb/

--- a/dockerfile
+++ b/dockerfile
@@ -1,14 +1,11 @@
 FROM pytorch/pytorch:1.13.0-cuda11.6-cudnn8-runtime
 
 # Install dependencies from requirements.txt
-# COPY requirements.txt .
-# RUN pip install -r requirements.txt
+COPY requirements.txt .
+RUN apt-get update && apt-get install -y git && pip install -r requirements.txt
 
 # Copy the rest of the code
 COPY . /home
 
 # Set the working directory to /app
 WORKDIR /home
-
-# install requirements
-RUN apt-get update && apt-get install -y git && pip install -r requirements.txt

--- a/src/decision_transformer/eval.py
+++ b/src/decision_transformer/eval.py
@@ -29,6 +29,7 @@ def evaluate_dt_agent(
     use_tqdm=True,
     device="cpu",
     num_envs=8,
+    trajectory_writer=None,
 ):
     model.eval()
 
@@ -168,6 +169,18 @@ def evaluate_dt_agent(
 
         # for each done, replace the obs, rtg, action, timestep with the new obs, rtg, action, timestep
         batch_reset_indexes = np.where(dones)
+
+        if trajectory_writer is not None and np.any(dones) and max_len > 1:
+            for i in batch_reset_indexes[0]: # Why do we have an array of one item here? Can this be multiple items?
+                trajectory_writer.accumulate_trajectory(
+                    next_obs=obs[i, ...].detach().cpu().numpy(),
+                    reward=np.array(rewards[i], dtype=float),
+                    done=np.array(dones[i], dtype=bool),
+                    truncated=np.array(truncated[i], dtype=bool),
+                    action=actions[i, ...].squeeze(-1).detach().cpu().numpy(), # No reason to have [16, max_len-1, 1] instead of [16, max_len-1]
+                    info=info
+                )
+
         if sum(dones) > 0:
             _new_obs = deepcopy(new_obs)
             _new_obs["image"] = _new_obs["image"][batch_reset_indexes]
@@ -242,6 +255,8 @@ def evaluate_dt_agent(
     }
 
     env.close()
+    if trajectory_writer is not None:
+        trajectory_writer.write()
     if track:
         # log statistics at batch number but prefix with eval
         for key, value in statistics.items():

--- a/src/decision_transformer/eval.py
+++ b/src/decision_transformer/eval.py
@@ -177,7 +177,8 @@ def evaluate_dt_agent(
                     reward=np.array(rewards[i], dtype=float),
                     done=np.array(dones[i], dtype=bool),
                     truncated=np.array(truncated[i], dtype=bool),
-                    action=actions[i, ...].squeeze(-1).detach().cpu().numpy(), # No reason to have [16, max_len-1, 1] instead of [16, max_len-1]
+                    rtg=np.array(rtg[i], dtype=float),
+                    action=actions[i, ...].detach().cpu().numpy(),
                     info=info
                 )
 

--- a/src/utils/trajectory_writer.py
+++ b/src/utils/trajectory_writer.py
@@ -61,8 +61,8 @@ class TrajectoryWriter:
         done: np.ndarray,
         truncated: np.ndarray,
         action: np.ndarray,
-        rtg: Optional[np.ndarray],
         info: Dict,
+        rtg: Optional[np.ndarray]=None,
     ):
         self.observations.append(next_obs)
         self.actions.append(action)

--- a/src/utils/trajectory_writer.py
+++ b/src/utils/trajectory_writer.py
@@ -5,7 +5,7 @@ import lzma
 import os
 import pickle
 import time
-from typing import Dict
+from typing import Dict, Optional
 
 import numpy as np
 from typeguard import typechecked
@@ -39,6 +39,7 @@ class TrajectoryWriter:
         self.rewards = []
         self.dones = []
         self.truncated = []
+        self.rtg = []
         self.infos = []
         self.path = path
 
@@ -60,6 +61,7 @@ class TrajectoryWriter:
         done: np.ndarray,
         truncated: np.ndarray,
         action: np.ndarray,
+        rtg: Optional[np.ndarray],
         info: Dict,
     ):
         self.observations.append(next_obs)
@@ -67,6 +69,8 @@ class TrajectoryWriter:
         self.rewards.append(reward)
         self.dones.append(done)
         self.truncated.append(truncated)
+        if rtg is not None:
+            self.rtg.append(rtg)
         self.infos.append(info)
 
     def tag_terminated_trajectories(self):
@@ -89,6 +93,7 @@ class TrajectoryWriter:
             "rewards": np.array(self.rewards, dtype=np.float),
             "dones": np.array(self.dones, dtype=bool),
             "truncated": np.array(self.truncated, dtype=bool),
+            "rtgs": np.array(self.rtg, dtype=np.float),
             "infos": np.array(self.infos, dtype=object),
         }
         if dataclasses.is_dataclass(self.args):

--- a/tests/acceptance/test_dt_train.py
+++ b/tests/acceptance/test_dt_train.py
@@ -1,11 +1,14 @@
 import copy
+import numpy as np 
+import os
+import pickle
 
 import pytest
 import torch
 from torch.utils.data import DataLoader, random_split
 from torch.utils.data.sampler import WeightedRandomSampler
 
-from src.config import EnvironmentConfig, TransformerModelConfig
+from src.config import EnvironmentConfig, OnlineTrainConfig, RunConfig, TransformerModelConfig
 from src.decision_transformer.offline_dataset import TrajectoryDataset
 from src.decision_transformer.train import test
 from src.decision_transformer.eval import evaluate_dt_agent
@@ -14,6 +17,7 @@ from src.models.trajectory_transformer import (
     CloneTransformer,
     DecisionTransformer,
 )
+from src.utils.trajectory_writer import TrajectoryWriter
 
 
 @pytest.fixture
@@ -24,6 +28,19 @@ def trajectory_data_set():
         trajectory_path, pct_traj=1, device=device
     )
     return trajectory_data_set
+
+
+@pytest.fixture
+def run_config():
+    run_config = RunConfig(
+        exp_name="test",
+        seed=1,
+        track=False,
+        wandb_project_name="test",
+        wandb_entity="test",
+    )
+
+    return run_config
 
 
 @pytest.fixture
@@ -40,6 +57,32 @@ def environment_config(trajectory_data_set):
     )
 
     return environment_config
+
+
+@pytest.fixture
+def online_config():
+    online_config = OnlineTrainConfig(
+        use_trajectory_model=False,
+        hidden_size=64,
+        total_timesteps=180000,
+        learning_rate=0.00025,
+        decay_lr=False,
+        num_envs=4,
+        num_steps=128,
+        gamma=0.99,
+        gae_lambda=0.95,
+        num_minibatches=4,
+        update_epochs=4,
+        clip_coef=0.4,
+        ent_coef=0.2,
+        vf_coef=0.5,
+        max_grad_norm=2,
+        trajectory_path=None,
+        fully_observed=False,
+        device=torch.device("cpu"),
+    )
+
+    return online_config
 
 
 @pytest.fixture
@@ -207,3 +250,65 @@ def test_evaluate_dt_agent(environment_config, dt):
     assert statistics["prop_positive_reward"] == 0.0
     # traj length approx 10
     assert statistics["mean_traj_length"] == pytest.approx(10.0, 1.0)
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        pytest.param("dt2 nctx = 5"),
+        pytest.param("dt3 nctx = 8"),
+    ],
+    indirect=True,
+)
+def test_evaluate_dt_agent_with_trajectory_writer(environment_config, dt, run_config, online_config):
+    trajectory_path = "tmp/test_trajectory_writer_writer.pkl"
+    n_ctx = dt.transformer_config.n_ctx
+    try:
+        environment_config.max_steps = 10  # speed up test
+        batch = 0
+        eval_env_func = make_env(
+            environment_config,
+            seed=batch,
+            idx=0,
+            run_name=f"dt_eval_videos_{batch}",
+        )
+
+        trajectory_writer = TrajectoryWriter(
+            path=trajectory_path,
+            run_config=run_config,
+            environment_config=environment_config,
+            online_config=online_config,
+            model_config=None,
+        )
+
+        statistics = evaluate_dt_agent(
+            env_id=environment_config.env_id,
+            model=dt,
+            env_func=eval_env_func,
+            track=False,
+            initial_rtg=1,
+            trajectories=10,
+            device="cuda" if torch.cuda.is_available() else "cpu",
+            trajectory_writer=trajectory_writer
+        )
+
+        assert os.path.getsize(trajectory_path) > 0
+        with open(trajectory_path, "rb") as f:
+            data = pickle.load(f)
+            obs = data["data"]["observations"]
+            assert type(obs) == np.ndarray
+            assert obs.dtype == np.float64
+            assert obs.shape == (16, 1 + n_ctx // 3, 7, 7, 3), f"obs.shape is {obs.shape}"
+
+            rewards = data["data"]["rewards"]
+            assert type(rewards) == np.ndarray
+            assert rewards.dtype == np.float64
+            assert rewards.shape == (16,), f"rewards.shape is {rewards.shape}"
+
+            actions = data["data"]["actions"]
+            assert type(actions) == np.ndarray
+            assert actions.dtype == np.int64
+            assert actions.shape == (16, n_ctx // 3), f"actions.shape is {actions.shape}"
+    finally:
+        if os.path.exists(trajectory_path):
+            os.remove(trajectory_path)

--- a/tests/acceptance/test_dt_train.py
+++ b/tests/acceptance/test_dt_train.py
@@ -300,15 +300,15 @@ def test_evaluate_dt_agent_with_trajectory_writer(environment_config, dt, run_co
             assert obs.dtype == np.float64
             assert obs.shape == (16, 1 + n_ctx // 3, 7, 7, 3), f"obs.shape is {obs.shape}"
 
-            rewards = data["data"]["rewards"]
-            assert type(rewards) == np.ndarray
-            assert rewards.dtype == np.float64
-            assert rewards.shape == (16,), f"rewards.shape is {rewards.shape}"
+            rtg = data["data"]["rtgs"]
+            assert type(rtg) == np.ndarray
+            assert rtg.dtype == np.float64
+            assert rtg.shape == (16, 1 + n_ctx // 3, 1), f"rtg.shape is {rtg.shape}"
 
             actions = data["data"]["actions"]
             assert type(actions) == np.ndarray
             assert actions.dtype == np.int64
-            assert actions.shape == (16, n_ctx // 3), f"actions.shape is {actions.shape}"
+            assert actions.shape == (16, n_ctx // 3, 1), f"actions.shape is {actions.shape}"
     finally:
         if os.path.exists(trajectory_path):
             os.remove(trajectory_path)


### PR DESCRIPTION
Also covers PR https://github.com/jbloomAus/DecisionTransformerInterpretability/pull/84 while I'm at it, which failed due to issues that were fixed in https://github.com/jbloomAus/DecisionTransformerInterpretability/pull/83

Added code to accumulate trajectories when evaluating a dt agent with a TrajectoryWriter passed to it, in order to collect actions, observations, and rtgs for probing techniques.