### PR TITLE
Added cache to most static analyses, refactored app.py.

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,10 +195,10 @@ if "Neuron Directions" in analyses:
     show_neuron_directions(dt)
 if "Congruence" in analyses:
     show_congruence(dt)
-if "QK Circuit" in analyses:
-    show_qk_circuit(dt)
 if "OV Circuit" in analyses:
     show_ov_circuit(dt)
+if "QK Circuit" in analyses:
+    show_qk_circuit(dt)
 if "Parameter Distributions" in analyses:
     show_param_statistics(dt)
 if "Show Dimensionality Reduction" in analyses:

--- a/app.py
+++ b/app.py
@@ -18,12 +18,13 @@ from src.streamlit_app.components import (
 
 
 from src.streamlit_app.dynamic_analysis_components import (
-    render_observation_view,
+    show_observation_view,
     show_attention_pattern,
     show_logit_lens,
     show_neuron_activation_decomposition,
     show_residual_stream_projection_onto_component,
     show_rtg_scan,
+    show_cache,
     show_gated_mlp_dynamic,
 )
 
@@ -34,7 +35,7 @@ from src.streamlit_app.static_analysis_components import (
     show_qk_circuit,
     show_congruence,
     show_param_statistics,
-    show_svd_virtual_weights,
+    show_dimensionality_reduction,
     show_composition_scores,
 )
 
@@ -152,7 +153,7 @@ with st.sidebar:
             "OV Circuit",
             "QK Circuit",
             "Parameter Distributions",
-            "SVD of Virtual Weights",
+            "Show Dimensionality Reduction",
             "Composition Scores",
         ],
     )
@@ -187,17 +188,25 @@ with st.sidebar:
 if len(analyses) == 0:
     st.warning("Please select at least one analysis.")
 
+# Static Analyses
 if "Embeddings" in analyses:
     show_embeddings(dt)
-if "Ablation" in analyses:
-    show_ablation(dt, logit_dir=logit_dir, original_cache=cache)
-if "Activation Patching" in analyses:
-    show_activation_patching(dt, logit_dir=logit_dir, original_cache=cache)
-if "Path Patching" in analyses:
-    show_path_patching(dt, logit_dir, clean_cache=cache)
-if "Algebraic Value Editing" in analyses:
-    show_algebraic_value_editing(dt, logit_dir=logit_dir, original_cache=cache)
+if "Neuron Directions" in analyses:
+    show_neuron_directions(dt)
+if "Congruence" in analyses:
+    show_congruence(dt)
+if "QK Circuit" in analyses:
+    show_qk_circuit(dt)
+if "OV Circuit" in analyses:
+    show_ov_circuit(dt)
+if "Parameter Distributions" in analyses:
+    show_param_statistics(dt)
+if "Show Dimensionality Reduction" in analyses:
+    show_dimensionality_reduction(dt)
+if "Composition Scores" in analyses:
+    show_composition_scores(dt)
 
+# Dynamic Analyses
 if "Show RTG Scan" in analyses:
     show_rtg_scan(dt, logit_dir=logit_dir)
 if "Logit Lens" in analyses:
@@ -209,27 +218,21 @@ if "Projection Analysis" in analyses:
 if "Attention Pattern" in analyses:
     show_attention_pattern(dt, cache)
 if "Observation View" in analyses:
-    render_observation_view(dt, tokens, logit_dir)
-
-if "GatedMLP" in analyses:
+    show_observation_view(dt, tokens, logit_dir)
+if "Cache" in analyses: # Not yet implemented.
+    show_cache(dt, cache)
+if "GatedMLP" in analyses: # Only appears for DTs with gated MLPs.
     show_gated_mlp_dynamic(dt, cache)
 
-
-if "Parameter Distributions" in analyses:
-    show_param_statistics(dt)
-if "Neuron Directions" in analyses:
-    show_neuron_directions(dt)
-if "SVD of Virtual Weights" in analyses:
-    show_svd_virtual_weights(dt)
-if "Composition Scores" in analyses:
-    show_composition_scores(dt)
-if "Congruence" in analyses:
-    show_congruence(dt)
-
-if "QK Circuit" in analyses:
-    show_qk_circuit(dt)
-if "OV Circuit" in analyses:
-    show_ov_circuit(dt)
+# Causal Analyses
+if "Ablation" in analyses:
+    show_ablation(dt, logit_dir=logit_dir, original_cache=cache)
+if "Activation Patching" in analyses:
+    show_activation_patching(dt, logit_dir=logit_dir, original_cache=cache)
+if "Path Patching" in analyses:
+    show_path_patching(dt, logit_dir, clean_cache=cache)
+if "Algebraic Value Editing" in analyses:
+    show_algebraic_value_editing(dt, logit_dir=logit_dir, original_cache=cache)
 
 show_history()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ numpy==1.23.5
 moviepy==1.0.3
 
 # streamlit
-streamlit==1.16.0
+streamlit==1.18.0
 altair==4.2.2
 
 # typeguard

--- a/src/streamlit_app/dynamic_analysis_components.py
+++ b/src/streamlit_app/dynamic_analysis_components.py
@@ -588,6 +588,8 @@ def plot_decomposition_dot_product(
 #             # plot_heatmap(similarities)
 #             fig = tensor_cosine_similarity_heatmap(result, labels)
 #             st.plotly_chart(fig, use_container_width=True)
+def show_cache(dt, cache):
+    st.warning("Cache not yet implemented")
 
 
 def show_residual_stream_projection_onto_component(dt, cache, logit_dir):
@@ -947,7 +949,7 @@ def show_rtg_scan(dt, logit_dir):
 
 
 # Observation View
-def render_observation_view(dt, tokens, logit_dir):
+def show_observation_view(dt, tokens, logit_dir):
     last_obs = st.session_state.obs[0][-1]
 
     last_obs_reshaped = rearrange(last_obs, "h w c -> c h w")

--- a/src/streamlit_app/environment.py
+++ b/src/streamlit_app/environment.py
@@ -14,7 +14,7 @@ from src.decision_transformer.utils import (
 from src.environments.environments import make_env
 
 
-@st.cache(allow_output_mutation=True)
+@st.cache_data
 def get_env_and_dt(model_path):
     # we need to one if the env was one hot encoded. Some tech debt here.
     state_dict = torch.load(model_path)

--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -1430,7 +1430,6 @@ def show_composition_scores(_dt):
         )
 
 
-@st.cache_data(experimental_allow_widgets=True)
 def embedding_projection_onto_svd_component(
     _dt, _reading_svd_projection, key="embeddings"
 ):
@@ -1546,7 +1545,6 @@ def embedding_projection_onto_svd_component(
         st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache_data(experimental_allow_widgets=True)
 def svd_out_to_svd_in_component(
     _dt, writing_svd_projection, _reading_svd_projection, key="composition type"
 ):
@@ -1644,7 +1642,6 @@ def svd_out_to_svd_in_component(
     )
 
 
-@st.cache_data(experimental_allow_widgets=True)
 def svd_out_to_mlp_in_component(_dt, V_OV):
     right_svd_vectors = st.slider(
         "Number of Singular Directions",
@@ -1715,7 +1712,6 @@ def svd_out_to_mlp_in_component(_dt, V_OV):
     )
 
 
-@st.cache_data(experimental_allow_widgets=True)
 def mlp_out_to_svd_in_component(
     _dt, _reading_svd_projection, key="mlp + composition type"
 ):
@@ -1840,7 +1836,6 @@ def svd_out_to_unembedding_component_top_k_variation(_dt, V_OV, W_U):
     st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache_data(experimental_allow_widgets=True)
 def svd_out_to_unembedding_component(_dt, V_OV, W_U):
     right_svd_vectors = st.slider(
         "Number of Singular Directions",
@@ -2023,7 +2018,6 @@ def show_dimensionality_reduction(_dt):
                 mlp_out_to_svd_in_component(_dt, V_OV_tmp, key="value")
 
 
-@st.cache_data(experimental_allow_widgets=True)
 def get_ov_circuit(_dt):
     # stack the heads
     W_V = torch.stack([block.attn.W_V for block in _dt.transformer.blocks])
@@ -2035,7 +2029,6 @@ def get_ov_circuit(_dt):
     return W_OV
 
 
-@st.cache_data(experimental_allow_widgets=True)
 def get_qk_circuit(_dt):
     # stack the heads
     W_Q = torch.stack([block.attn.W_Q for block in _dt.transformer.blocks])

--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -59,7 +59,7 @@ embedding_labels = (
 )
 
 
-@st.cache
+@st.cache_data
 def show_param_statistics(dt):
     with st.expander("Show Parameter Statistics"):
         df = get_param_stats(dt)
@@ -70,7 +70,7 @@ def show_param_statistics(dt):
         st.plotly_chart(fig_norm, use_container_width=True)
 
 
-@st.cache
+@st.cache_data
 def show_embeddings(dt):
     with st.expander("Embeddings"):
         all_index_labels = [
@@ -341,7 +341,7 @@ def show_embeddings(dt):
                 st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache
+@st.cache_data
 def show_neuron_directions(dt):
     MLP_in = torch.stack(
         [block.mlp.W_in for block in dt.transformer.blocks]
@@ -376,7 +376,7 @@ def show_neuron_directions(dt):
     return
 
 
-@st.cache
+@st.cache_data
 def show_qk_circuit(dt):
     with st.expander("show QK circuit"):
         st.write(
@@ -721,7 +721,7 @@ def show_qk_circuit(dt):
                         )
 
 
-@st.cache
+@st.cache_data
 def show_ov_circuit(dt):
     with st.expander("Show OV Circuit"):
         st.subheader("OV circuits")
@@ -954,7 +954,7 @@ def show_ov_circuit(dt):
                             )
 
 
-@st.cache
+@st.cache_data
 def show_congruence(dt):
     with st.expander("Show Congruence"):
         (
@@ -1265,7 +1265,7 @@ def show_congruence(dt):
         st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache
+@st.cache_data
 def show_composition_scores(dt):
     with st.expander("Show Composition Scores"):
         st.markdown(
@@ -1430,7 +1430,7 @@ def show_composition_scores(dt):
         )
 
 
-@st.cache
+@st.cache_data
 def embedding_projection_onto_svd_component(
     dt, reading_svd_projection, key="embeddings"
 ):
@@ -1546,7 +1546,7 @@ def embedding_projection_onto_svd_component(
         st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache
+@st.cache_data
 def svd_out_to_svd_in_component(
     dt, writing_svd_projection, reading_svd_projection, key="composition type"
 ):
@@ -1644,7 +1644,7 @@ def svd_out_to_svd_in_component(
     )
 
 
-@st.cache
+@st.cache_data
 def svd_out_to_mlp_in_component(dt, V_OV):
     right_svd_vectors = st.slider(
         "Number of Singular Directions",
@@ -1715,7 +1715,7 @@ def svd_out_to_mlp_in_component(dt, V_OV):
     )
 
 
-@st.cache
+@st.cache_data
 def mlp_out_to_svd_in_component(
     dt, reading_svd_projection, key="mlp + composition type"
 ):
@@ -1794,7 +1794,7 @@ def mlp_out_to_svd_in_component(
     )
 
 
-@st.cache
+@st.cache_data
 def svd_out_to_unembedding_component_top_k_variation(dt, V_OV, W_U):
     """
     This version of this analysis is based on "The SVD Decomposition is Highly Interpretable"
@@ -1840,7 +1840,7 @@ def svd_out_to_unembedding_component_top_k_variation(dt, V_OV, W_U):
     st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache
+@st.cache_data
 def svd_out_to_unembedding_component(dt, V_OV, W_U):
     right_svd_vectors = st.slider(
         "Number of Singular Directions",
@@ -1932,7 +1932,7 @@ def svd_out_to_unembedding_component(dt, V_OV, W_U):
     # st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache
+@st.cache_data
 def show_dimensionality_reduction(dt):
     with st.expander("Analysis of Virtual Weights"):
         # get head objects.
@@ -2023,7 +2023,7 @@ def show_dimensionality_reduction(dt):
                 mlp_out_to_svd_in_component(dt, V_OV_tmp, key="value")
 
 
-@st.cache
+@st.cache_data
 def get_ov_circuit(dt):
     # stack the heads
     W_V = torch.stack([block.attn.W_V for block in dt.transformer.blocks])
@@ -2035,7 +2035,7 @@ def get_ov_circuit(dt):
     return W_OV
 
 
-@st.cache
+@st.cache_data
 def get_qk_circuit(dt):
     # stack the heads
     W_Q = torch.stack([block.attn.W_Q for block in dt.transformer.blocks])
@@ -2050,7 +2050,7 @@ def get_qk_circuit(dt):
     return W_QK
 
 
-@st.cache
+@st.cache_data
 def plot_svd_by_head_layer(dt, S):
     d_head = dt.transformer_config.d_head
     labels = [
@@ -2072,7 +2072,7 @@ def plot_svd_by_head_layer(dt, S):
     st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache
+@st.cache_data
 def layer_head_k_selector_ui(dt, key=""):
     n_actions = dt.action_predictor.weight.shape[0]
     layer_selection, head_selection, k_selection, d_selection = st.columns(4)
@@ -2118,7 +2118,7 @@ def layer_head_k_selector_ui(dt, key=""):
     return layer, head, k, dims
 
 
-@st.cache
+@st.cache_data
 def embedding_matrix_selection_ui(dt):
     embedding_matrix_selection = st.columns(2)
     with embedding_matrix_selection[0]:
@@ -2155,7 +2155,7 @@ def embedding_matrix_selection_ui(dt):
     return embedding_matrix_1, embedding_matrix_2
 
 
-@st.cache
+@st.cache_data
 def layer_head_channel_selector(dt, key=""):
     n_heads = dt.transformer_config.n_heads
     height, width, channels = dt.environment_config.observation_space[

--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -2155,7 +2155,6 @@ def embedding_matrix_selection_ui(_dt):
     return embedding_matrix_1, embedding_matrix_2
 
 
-@st.cache_data(experimental_allow_widgets=True)
 def layer_head_channel_selector(_dt, key=""):
     n_heads = _dt.transformer_config.n_heads
     height, width, channels = _dt.environment_config.observation_space[

--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -59,6 +59,7 @@ embedding_labels = (
 )
 
 
+@st.cache
 def show_param_statistics(dt):
     with st.expander("Show Parameter Statistics"):
         df = get_param_stats(dt)
@@ -69,6 +70,7 @@ def show_param_statistics(dt):
         st.plotly_chart(fig_norm, use_container_width=True)
 
 
+@st.cache
 def show_embeddings(dt):
     with st.expander("Embeddings"):
         all_index_labels = [
@@ -339,6 +341,7 @@ def show_embeddings(dt):
                 st.plotly_chart(fig, use_container_width=True)
 
 
+@st.cache
 def show_neuron_directions(dt):
     MLP_in = torch.stack(
         [block.mlp.W_in for block in dt.transformer.blocks]
@@ -373,6 +376,7 @@ def show_neuron_directions(dt):
     return
 
 
+@st.cache
 def show_qk_circuit(dt):
     with st.expander("show QK circuit"):
         st.write(
@@ -717,6 +721,7 @@ def show_qk_circuit(dt):
                         )
 
 
+@st.cache
 def show_ov_circuit(dt):
     with st.expander("Show OV Circuit"):
         st.subheader("OV circuits")
@@ -949,6 +954,7 @@ def show_ov_circuit(dt):
                             )
 
 
+@st.cache
 def show_congruence(dt):
     with st.expander("Show Congruence"):
         (
@@ -1259,6 +1265,7 @@ def show_congruence(dt):
         st.plotly_chart(fig, use_container_width=True)
 
 
+@st.cache
 def show_composition_scores(dt):
     with st.expander("Show Composition Scores"):
         st.markdown(
@@ -1423,6 +1430,7 @@ def show_composition_scores(dt):
         )
 
 
+@st.cache
 def embedding_projection_onto_svd_component(
     dt, reading_svd_projection, key="embeddings"
 ):
@@ -1538,6 +1546,7 @@ def embedding_projection_onto_svd_component(
         st.plotly_chart(fig, use_container_width=True)
 
 
+@st.cache
 def svd_out_to_svd_in_component(
     dt, writing_svd_projection, reading_svd_projection, key="composition type"
 ):
@@ -1635,6 +1644,7 @@ def svd_out_to_svd_in_component(
     )
 
 
+@st.cache
 def svd_out_to_mlp_in_component(dt, V_OV):
     right_svd_vectors = st.slider(
         "Number of Singular Directions",
@@ -1705,6 +1715,7 @@ def svd_out_to_mlp_in_component(dt, V_OV):
     )
 
 
+@st.cache
 def mlp_out_to_svd_in_component(
     dt, reading_svd_projection, key="mlp + composition type"
 ):
@@ -1783,6 +1794,7 @@ def mlp_out_to_svd_in_component(
     )
 
 
+@st.cache
 def svd_out_to_unembedding_component_top_k_variation(dt, V_OV, W_U):
     """
     This version of this analysis is based on "The SVD Decomposition is Highly Interpretable"
@@ -1828,6 +1840,7 @@ def svd_out_to_unembedding_component_top_k_variation(dt, V_OV, W_U):
     st.plotly_chart(fig, use_container_width=True)
 
 
+@st.cache
 def svd_out_to_unembedding_component(dt, V_OV, W_U):
     right_svd_vectors = st.slider(
         "Number of Singular Directions",
@@ -1919,7 +1932,8 @@ def svd_out_to_unembedding_component(dt, V_OV, W_U):
     # st.plotly_chart(fig, use_container_width=True)
 
 
-def show_svd_virtual_weights(dt):
+@st.cache
+def show_dimensionality_reduction(dt):
     with st.expander("Analysis of Virtual Weights"):
         # get head objects.
         W_QK = get_qk_circuit(dt)
@@ -2009,6 +2023,7 @@ def show_svd_virtual_weights(dt):
                 mlp_out_to_svd_in_component(dt, V_OV_tmp, key="value")
 
 
+@st.cache
 def get_ov_circuit(dt):
     # stack the heads
     W_V = torch.stack([block.attn.W_V for block in dt.transformer.blocks])
@@ -2020,6 +2035,7 @@ def get_ov_circuit(dt):
     return W_OV
 
 
+@st.cache
 def get_qk_circuit(dt):
     # stack the heads
     W_Q = torch.stack([block.attn.W_Q for block in dt.transformer.blocks])
@@ -2034,6 +2050,7 @@ def get_qk_circuit(dt):
     return W_QK
 
 
+@st.cache
 def plot_svd_by_head_layer(dt, S):
     d_head = dt.transformer_config.d_head
     labels = [
@@ -2055,6 +2072,7 @@ def plot_svd_by_head_layer(dt, S):
     st.plotly_chart(fig, use_container_width=True)
 
 
+@st.cache
 def layer_head_k_selector_ui(dt, key=""):
     n_actions = dt.action_predictor.weight.shape[0]
     layer_selection, head_selection, k_selection, d_selection = st.columns(4)
@@ -2100,6 +2118,7 @@ def layer_head_k_selector_ui(dt, key=""):
     return layer, head, k, dims
 
 
+@st.cache
 def embedding_matrix_selection_ui(dt):
     embedding_matrix_selection = st.columns(2)
     with embedding_matrix_selection[0]:
@@ -2136,6 +2155,7 @@ def embedding_matrix_selection_ui(dt):
     return embedding_matrix_1, embedding_matrix_2
 
 
+@st.cache
 def layer_head_channel_selector(dt, key=""):
     n_heads = dt.transformer_config.n_heads
     height, width, channels = dt.environment_config.observation_space[

--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -59,10 +59,10 @@ embedding_labels = (
 )
 
 
-@st.cache_data
-def show_param_statistics(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def show_param_statistics(_dt):
     with st.expander("Show Parameter Statistics"):
-        df = get_param_stats(dt)
+        df = get_param_stats(_dt)
         fig_mean, fig_log_std, fig_norm = plot_param_stats(df)
 
         st.plotly_chart(fig_mean, use_container_width=True)
@@ -70,8 +70,8 @@ def show_param_statistics(dt):
         st.plotly_chart(fig_norm, use_container_width=True)
 
 
-@st.cache_data
-def show_embeddings(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def show_embeddings(_dt):
     with st.expander("Embeddings"):
         all_index_labels = [
             SPARSE_CHANNEL_NAMES,
@@ -123,7 +123,7 @@ def show_embeddings(dt):
                             default=[5, 6],
                         )
 
-                embedding = dt.state_embedding.weight.detach().T
+                embedding = _dt.state_embedding.weight.detach().T
 
                 if aggregation_group == "None":
                     fig = tensor_cosine_similarity_heatmap(
@@ -135,7 +135,7 @@ def show_embeddings(dt):
                     st.plotly_chart(fig, use_container_width=True)
 
                 if aggregation_group == "Channels":
-                    image_shape = dt.environment_config.observation_space[
+                    image_shape = _dt.environment_config.observation_space[
                         "image"
                     ].shape
 
@@ -187,7 +187,7 @@ def show_embeddings(dt):
                     st.plotly_chart(fig, use_container_width=True)
 
                 if aggregation_group == "Positions":
-                    image_shape = dt.environment_config.observation_space[
+                    image_shape = _dt.environment_config.observation_space[
                         "image"
                     ].shape
 
@@ -213,7 +213,7 @@ def show_embeddings(dt):
                     st.plotly_chart(fig, use_container_width=True)
 
             with in_action_tab:
-                embedding = dt.action_embedding[0].weight.detach()
+                embedding = _dt.action_embedding[0].weight.detach()
                 fig = tensor_cosine_similarity_heatmap(
                     embedding, labels=ACTION_NAMES
                 )
@@ -221,7 +221,7 @@ def show_embeddings(dt):
                 st.plotly_chart(fig, use_container_width=True)
 
             with out_action_tab:
-                embedding = dt.action_predictor.weight.detach()
+                embedding = _dt.action_predictor.weight.detach()
                 fig = tensor_cosine_similarity_heatmap(
                     embedding, labels=ACTION_NAMES
                 )
@@ -234,7 +234,7 @@ def show_embeddings(dt):
             )
 
             with state_tab:
-                embedding = dt.state_embedding.weight.detach().T
+                embedding = _dt.state_embedding.weight.detach().T
 
                 with st.spinner("Performing PCA..."):
                     # Normalize the data
@@ -273,7 +273,7 @@ def show_embeddings(dt):
                 st.plotly_chart(fig, use_container_width=True)
 
             with in_action_tab:
-                embedding = dt.action_embedding[0].weight.detach()
+                embedding = _dt.action_embedding[0].weight.detach()
 
                 with st.spinner("Performing PCA..."):
                     # Normalize the data
@@ -307,7 +307,7 @@ def show_embeddings(dt):
                 st.plotly_chart(fig, use_container_width=True)
 
             with out_action_tab:
-                embedding = dt.action_predictor.weight.detach()
+                embedding = _dt.action_predictor.weight.detach()
 
                 with st.spinner("Performing PCA..."):
                     # Normalize the data
@@ -341,17 +341,17 @@ def show_embeddings(dt):
                 st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache_data
-def show_neuron_directions(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def show_neuron_directions(_dt):
     MLP_in = torch.stack(
-        [block.mlp.W_in for block in dt.transformer.blocks]
+        [block.mlp.W_in for block in _dt.transformer.blocks]
     ).detach()
 
     MLP_out = torch.stack(
-        [block.mlp.W_out for block in dt.transformer.blocks]
+        [block.mlp.W_out for block in _dt.transformer.blocks]
     ).detach()
 
-    layers = dt.transformer_config.n_layers
+    layers = _dt.transformer_config.n_layers
 
     with st.expander("Show Neuron In / Out Directions"):
         in_tab, out_tab = st.tabs(["In", "Out"])
@@ -376,8 +376,8 @@ def show_neuron_directions(dt):
     return
 
 
-@st.cache_data
-def show_qk_circuit(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def show_qk_circuit(_dt):
     with st.expander("show QK circuit"):
         st.write(
             """
@@ -418,15 +418,15 @@ def show_qk_circuit(dt):
         #     )
         #     st.write(W_QK_full_reshaped.shape)
 
-        height, width, channels = dt.environment_config.observation_space[
+        height, width, channels = _dt.environment_config.observation_space[
             "image"
         ].shape
-        n_heads = dt.transformer_config.n_heads
-        layers = dt.transformer_config.n_layers
+        n_heads = _dt.transformer_config.n_heads
+        layers = _dt.transformer_config.n_layers
 
         # stack the heads
-        W_Q = torch.stack([block.attn.W_Q for block in dt.transformer.blocks])
-        W_K = torch.stack([block.attn.W_K for block in dt.transformer.blocks])
+        W_Q = torch.stack([block.attn.W_Q for block in _dt.transformer.blocks])
+        W_K = torch.stack([block.attn.W_K for block in _dt.transformer.blocks])
         # inner QK circuits.
         W_QK = einsum(
             "layer head d_model1 d_head, layer head d_model2 d_head -> layer head d_model1 d_model2",
@@ -434,8 +434,8 @@ def show_qk_circuit(dt):
             W_K,
         )
 
-        W_E_rtg = dt.reward_embedding[0].weight
-        W_E_state = dt.state_embedding.weight
+        W_E_rtg = _dt.reward_embedding[0].weight
+        W_E_state = _dt.state_embedding.weight
         with state_state_tab:
             st.write(
                 """
@@ -681,7 +681,7 @@ def show_qk_circuit(dt):
                 st.plotly_chart(fig, use_container_width=True)
 
             layer, heads, selected_channels = layer_head_channel_selector(
-                dt, key="srtg"
+                _dt, key="srtg"
             )
             abs_max_val = W_QK_full_reshaped.abs().max().item()
             abs_max_val = st.slider(
@@ -721,8 +721,8 @@ def show_qk_circuit(dt):
                         )
 
 
-@st.cache_data
-def show_ov_circuit(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def show_ov_circuit(_dt):
     with st.expander("Show OV Circuit"):
         st.subheader("OV circuits")
 
@@ -732,11 +732,11 @@ def show_ov_circuit(dt):
             """
         )
 
-        height, width, channels = dt.environment_config.observation_space[
+        height, width, channels = _dt.environment_config.observation_space[
             "image"
         ].shape
-        n_actions = dt.environment_config.action_space.n
-        n_heads = dt.transformer_config.n_heads
+        n_actions = _dt.environment_config.action_space.n
+        n_heads = _dt.transformer_config.n_heads
 
         if channels == 3:
 
@@ -750,7 +750,7 @@ def show_ov_circuit(dt):
         with selection_columns[0]:
             layer = st.selectbox(
                 "Select Layer",
-                options=list(range(dt.transformer_config.n_layers)),
+                options=list(range(_dt.transformer_config.n_layers)),
             )
 
         with selection_columns[1]:
@@ -779,10 +779,10 @@ def show_ov_circuit(dt):
                 default=[0, 1, 2],
             )
 
-        W_U = dt.action_predictor.weight
-        W_O = dt.transformer.blocks[layer].attn.W_O
-        W_V = dt.transformer.blocks[layer].attn.W_V
-        W_E = dt.state_embedding.weight
+        W_U = _dt.action_predictor.weight
+        W_O = _dt.transformer.blocks[layer].attn.W_O
+        W_V = _dt.transformer.blocks[layer].attn.W_V
+        W_E = _dt.state_embedding.weight
         W_OV = W_V @ W_O
 
         # st.plotly_chart(px.imshow(W_OV.detach().numpy(), facet_col=0), use_container_width=True)
@@ -954,8 +954,8 @@ def show_ov_circuit(dt):
                             )
 
 
-@st.cache_data
-def show_congruence(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def show_congruence(_dt):
     with st.expander("Show Congruence"):
         (
             position_tab,
@@ -978,7 +978,7 @@ def show_congruence(dt):
         )
 
         position_action_mapping = (
-            dt.transformer.W_pos @ dt.action_predictor.weight.T
+            _dt.transformer.W_pos @ _dt.action_predictor.weight.T
         )
         fig = px.imshow(
             position_action_mapping.T.detach().numpy(),
@@ -997,7 +997,7 @@ def show_congruence(dt):
         )
 
         time_action_mapping = (
-            dt.time_embedding.weight[:50, :] @ dt.action_predictor.weight.T
+            _dt.time_embedding.weight[:50, :] @ _dt.action_predictor.weight.T
         )
         fig = px.imshow(
             time_action_mapping.T.detach().numpy(),
@@ -1007,9 +1007,9 @@ def show_congruence(dt):
         st.plotly_chart(fig, use_container_width=True)
 
     with w_out_tab:
-        W_0 = torch.stack([block.attn.W_O for block in dt.transformer.blocks])
+        W_0 = torch.stack([block.attn.W_O for block in _dt.transformer.blocks])
 
-        W_0_congruence = W_0 @ dt.action_predictor.weight.T
+        W_0_congruence = W_0 @ _dt.action_predictor.weight.T
         W_0_congruence = W_0_congruence.permute(0, 1, 3, 2)
         W_0_congruence = W_0_congruence.detach()
 
@@ -1048,13 +1048,13 @@ def show_congruence(dt):
 
     with mlp_in_tab:
         MLP_in = torch.stack(
-            [block.mlp.W_in for block in dt.transformer.blocks]
+            [block.mlp.W_in for block in _dt.transformer.blocks]
         )
         # MLP_in = MLP_in / (torch.norm(MLP_in, dim=-1, keepdim=True) + 1e-8)
         state_tab, action_tab, rtg_tab = st.tabs(["State", "Action", "RTG"])
 
         with state_tab:
-            state_in = dt.state_embedding.weight
+            state_in = _dt.state_embedding.weight
 
             # state_in_normalized = state_in / (torch.norm(state_in, dim=-1, keepdim=True) + 1e-8)
 
@@ -1141,7 +1141,7 @@ def show_congruence(dt):
             # st.write(bottom_40)
 
         with action_tab:
-            action_in = dt.action_embedding[0].weight
+            action_in = _dt.action_embedding[0].weight
             MLP_in_action_congruence = MLP_in.permute(0, 2, 1) @ action_in.T
 
             MLP_in_action_congruence = MLP_in_action_congruence.permute(
@@ -1184,7 +1184,7 @@ def show_congruence(dt):
             st.plotly_chart(fig, use_container_width=True)
 
         with rtg_tab:
-            rtg_in = dt.reward_embedding[0].weight
+            rtg_in = _dt.reward_embedding[0].weight
             # rtg_in_normalized =
 
             st.write(rtg_in.norm())
@@ -1220,12 +1220,12 @@ def show_congruence(dt):
 
     with mlp_out_tab:
         MLP_out = torch.stack(
-            [block.mlp.W_out for block in dt.transformer.blocks]
+            [block.mlp.W_out for block in _dt.transformer.blocks]
         )
 
         # MLP_out = MLP_out / MLP_out.norm(dim=-1, keepdim=True)
 
-        action_predictor = dt.action_predictor.weight
+        action_predictor = _dt.action_predictor.weight
         # action_predictor = action_predictor / action_predictor.norm(
         #     dim=-1, keepdim=True
         # )
@@ -1265,16 +1265,16 @@ def show_congruence(dt):
         st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache_data
-def show_composition_scores(dt):
+# TODO: Add st.cache_data here.
+def show_composition_scores(_dt):
     with st.expander("Show Composition Scores"):
         st.markdown(
             "Composition Score calculations per [Mathematical Frameworks for Transformer Circuits](https://transformer-circuits.pub/2021/framework/index.html#:~:text=The%20above%20diagram%20shows%20Q%2D%2C%20K%2D%2C%20and%20V%2DComposition)"
         )
 
-        q_scores = dt.transformer.all_composition_scores("Q")
-        k_scores = dt.transformer.all_composition_scores("K")
-        v_scores = dt.transformer.all_composition_scores("V")
+        q_scores = _dt.transformer.all_composition_scores("Q")
+        k_scores = _dt.transformer.all_composition_scores("K")
+        v_scores = _dt.transformer.all_composition_scores("V")
 
         dims = ["L1", "H1", "L2", "H2"]
 
@@ -1430,14 +1430,14 @@ def show_composition_scores(dt):
         )
 
 
-@st.cache_data
+@st.cache_data(experimental_allow_widgets=True)
 def embedding_projection_onto_svd_component(
-    dt, reading_svd_projection, key="embeddings"
+    _dt, _reading_svd_projection, key="embeddings"
 ):
-    U = reading_svd_projection
-    W_E_state = dt.state_embedding.weight.detach().T
-    W_E_action = dt.action_embedding[0].weight.detach().T
-    W_E_reward = dt.reward_embedding[0].weight.detach().T
+    U = _reading_svd_projection
+    W_E_state = _dt.state_embedding.weight.detach().T
+    W_E_action = _dt.action_embedding[0].weight.detach().T
+    W_E_reward = _dt.reward_embedding[0].weight.detach().T
 
     state_tab, rtg_tab = st.tabs(["State", "RTG"])  # , "Action"]
 
@@ -1445,7 +1445,7 @@ def embedding_projection_onto_svd_component(
         left_svd_vectors = st.slider(
             "Number of Singular Directions",
             min_value=3,
-            max_value=dt.transformer_config.d_head,
+            max_value=_dt.transformer_config.d_head,
             key=f"state out, head svd, {key}",
         )
 
@@ -1495,14 +1495,14 @@ def embedding_projection_onto_svd_component(
         )
 
     with rtg_tab:
-        W_E = dt.reward_embedding[0].weight.T
+        W_E = _dt.reward_embedding[0].weight.T
         # W_pos_e = dt.transformer.W_pos
         # W_E = W_E.T + W_pos_e
 
         left_svd_vectors = st.slider(
             "Number of Singular Directions",
             min_value=3,
-            max_value=dt.transformer_config.d_head,
+            max_value=_dt.transformer_config.d_head,
             key=f"embed rtg, left svd {key}",
         )
 
@@ -1546,11 +1546,11 @@ def embedding_projection_onto_svd_component(
         st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache_data
+@st.cache_data(experimental_allow_widgets=True)
 def svd_out_to_svd_in_component(
-    dt, writing_svd_projection, reading_svd_projection, key="composition type"
+    _dt, writing_svd_projection, _reading_svd_projection, key="composition type"
 ):
-    U = reading_svd_projection
+    U = _reading_svd_projection
     V = writing_svd_projection
 
     a, b = st.columns(2)
@@ -1558,14 +1558,14 @@ def svd_out_to_svd_in_component(
         left_svd_vectors = st.slider(
             "Number of Singular Directions (out)",
             min_value=3,
-            max_value=dt.transformer_config.d_head,
+            max_value=_dt.transformer_config.d_head,
             key="head head left" + key,
         )
     with b:
         right_svd_vectors = st.slider(
             "Number of Singular Directions (in)",
             min_value=3,
-            max_value=dt.transformer_config.d_head,
+            max_value=_dt.transformer_config.d_head,
             key="head head right" + key,
         )
 
@@ -1644,16 +1644,16 @@ def svd_out_to_svd_in_component(
     )
 
 
-@st.cache_data
-def svd_out_to_mlp_in_component(dt, V_OV):
+@st.cache_data(experimental_allow_widgets=True)
+def svd_out_to_mlp_in_component(_dt, V_OV):
     right_svd_vectors = st.slider(
         "Number of Singular Directions",
         min_value=3,
-        max_value=dt.transformer_config.d_head,
+        max_value=_dt.transformer_config.d_head,
         key="svd out to mlp in",
     )
 
-    MLP_in = torch.stack([block.mlp.W_in for block in dt.transformer.blocks])
+    MLP_in = torch.stack([block.mlp.W_in for block in _dt.transformer.blocks])
     V_filtered = V_OV[:, :, :right_svd_vectors, :]
     activations = einsum(
         "l1 h1 d_head_out d_head_ext, l2 d_head_ext d_mlp_in -> l2 l1 h1 d_head_out d_mlp_in",
@@ -1715,20 +1715,20 @@ def svd_out_to_mlp_in_component(dt, V_OV):
     )
 
 
-@st.cache_data
+@st.cache_data(experimental_allow_widgets=True)
 def mlp_out_to_svd_in_component(
-    dt, reading_svd_projection, key="mlp + composition type"
+    _dt, _reading_svd_projection, key="mlp + composition type"
 ):
-    U = reading_svd_projection
+    U = _reading_svd_projection
     left_svd_vectors = st.slider(
         "Number of Singular Directions (in)",
         min_value=3,
-        max_value=dt.transformer_config.d_head,
+        max_value=_dt.transformer_config.d_head,
         key="svd out to mlp in" + key,
     )
     U_filtered = U[:, :, :left_svd_vectors, :]
 
-    MLP_out = torch.stack([block.mlp.W_out for block in dt.transformer.blocks])
+    MLP_out = torch.stack([block.mlp.W_out for block in _dt.transformer.blocks])
 
     # MLP_out = MLP_out / MLP_out.norm(dim=(-2,-1), keepdim=True)
 
@@ -1794,8 +1794,8 @@ def mlp_out_to_svd_in_component(
     )
 
 
-@st.cache_data
-def svd_out_to_unembedding_component_top_k_variation(dt, V_OV, W_U):
+@st.cache_data(experimental_allow_widgets=True)
+def svd_out_to_unembedding_component_top_k_variation(_dt, V_OV, W_U):
     """
     This version of this analysis is based on "The SVD Decomposition is Highly Interpretable"
     Conjecture LessWrong post.
@@ -1812,7 +1812,7 @@ def svd_out_to_unembedding_component_top_k_variation(dt, V_OV, W_U):
     # torch.Size([3, 8, 7, 256])
     # Now we want to select a head/layer and plot the imshow of the activations
     # only for the first n activations
-    layer, head, k, dims = layer_head_k_selector_ui(dt, key="ov")
+    layer, head, k, dims = layer_head_k_selector_ui(_dt, key="ov")
 
     head_v_projections = activations[layer, head, :dims, :].detach()
 
@@ -1840,12 +1840,12 @@ def svd_out_to_unembedding_component_top_k_variation(dt, V_OV, W_U):
     st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache_data
-def svd_out_to_unembedding_component(dt, V_OV, W_U):
+@st.cache_data(experimental_allow_widgets=True)
+def svd_out_to_unembedding_component(_dt, V_OV, W_U):
     right_svd_vectors = st.slider(
         "Number of Singular Directions",
         min_value=3,
-        max_value=dt.transformer_config.d_head,
+        max_value=_dt.transformer_config.d_head,
         key="svd out to unembedding",
     )
 
@@ -1932,15 +1932,15 @@ def svd_out_to_unembedding_component(dt, V_OV, W_U):
     # st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache_data
-def show_dimensionality_reduction(dt):
-    with st.expander("Analysis of Virtual Weights"):
+@st.cache_data(experimental_allow_widgets=True)
+def show_dimensionality_reduction(_dt):
+    with st.expander("Dimensionality Reduction"):
         # get head objects.
-        W_QK = get_qk_circuit(dt)
+        W_QK = get_qk_circuit(_dt)
         U_QK, S_QK, V_QK = torch.linalg.svd(W_QK)
-        W_OV = get_ov_circuit(dt)
+        W_OV = get_ov_circuit(_dt)
         U_OV, S_OV, V_OV = torch.linalg.svd(W_OV)
-        W_U = dt.action_predictor.weight
+        W_U = _dt.action_predictor.weight
 
         a, b = st.columns(2)
         with a:
@@ -1956,15 +1956,15 @@ def show_dimensionality_reduction(dt):
                 ["Keys", "Queries", "Values"]
             )
             with keys_tab:
-                embedding_projection_onto_svd_component(dt, V_QK, key="keys")
+                embedding_projection_onto_svd_component(_dt, V_QK, key="keys")
 
             with queries_tab:
                 embedding_projection_onto_svd_component(
-                    dt, U_QK, key="queries"
+                    _dt, U_QK, key="queries"
                 )
 
             with values_tab:
-                embedding_projection_onto_svd_component(dt, V_OV, key="values")
+                embedding_projection_onto_svd_component(_dt, V_OV, key="values")
 
         if selected_writer == "Head Output":
             (
@@ -1986,25 +1986,25 @@ def show_dimensionality_reduction(dt):
             with key_composition_tab:
                 V_Q_tmp = V_QK.permute(0, 1, 3, 2)
                 svd_out_to_svd_in_component(
-                    dt, U_OV, V_Q_tmp, key="key composition"
+                    _dt, U_OV, V_Q_tmp, key="key composition"
                 )
 
             with query_composition_tab:
                 svd_out_to_svd_in_component(
-                    dt, U_OV, U_QK, key="query composition"
+                    _dt, U_OV, U_QK, key="query composition"
                 )
 
             with value_composition_tab:
                 V_OV_tmp = V_OV.permute(0, 1, 3, 2)
                 svd_out_to_svd_in_component(
-                    dt, U_OV, V_OV_tmp, key="value composition"
+                    _dt, U_OV, V_OV_tmp, key="value composition"
                 )
 
             with mlp_in_tab:
-                svd_out_to_mlp_in_component(dt, V_OV)
+                svd_out_to_mlp_in_component(_dt, V_OV)
 
             with unembedding_tab:
-                svd_out_to_unembedding_component(dt, V_OV, W_U)
+                svd_out_to_unembedding_component(_dt, V_OV, W_U)
 
         if selected_writer == "Neuron Output":
             key_tab, query_tab, value_tab = st.tabs(
@@ -2013,21 +2013,21 @@ def show_dimensionality_reduction(dt):
 
             with key_tab:
                 V_QK_tmp = V_QK.permute(0, 1, 3, 2)
-                mlp_out_to_svd_in_component(dt, V_QK_tmp, key="key")
+                mlp_out_to_svd_in_component(_dt, V_QK_tmp, key="key")
 
             with query_tab:
-                mlp_out_to_svd_in_component(dt, U_QK, key="query")
+                mlp_out_to_svd_in_component(_dt, U_QK, key="query")
 
             with value_tab:
                 V_OV_tmp = V_OV.permute(0, 1, 3, 2)
-                mlp_out_to_svd_in_component(dt, V_OV_tmp, key="value")
+                mlp_out_to_svd_in_component(_dt, V_OV_tmp, key="value")
 
 
-@st.cache_data
-def get_ov_circuit(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def get_ov_circuit(_dt):
     # stack the heads
-    W_V = torch.stack([block.attn.W_V for block in dt.transformer.blocks])
-    W_0 = torch.stack([block.attn.W_O for block in dt.transformer.blocks])
+    W_V = torch.stack([block.attn.W_V for block in _dt.transformer.blocks])
+    W_0 = torch.stack([block.attn.W_O for block in _dt.transformer.blocks])
 
     # inner OV circuits.
     W_OV = torch.einsum("lhmd,lhdn->lhmn", W_V, W_0)
@@ -2035,11 +2035,11 @@ def get_ov_circuit(dt):
     return W_OV
 
 
-@st.cache_data
-def get_qk_circuit(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def get_qk_circuit(_dt):
     # stack the heads
-    W_Q = torch.stack([block.attn.W_Q for block in dt.transformer.blocks])
-    W_K = torch.stack([block.attn.W_K for block in dt.transformer.blocks])
+    W_Q = torch.stack([block.attn.W_Q for block in _dt.transformer.blocks])
+    W_K = torch.stack([block.attn.W_K for block in _dt.transformer.blocks])
     # inner QK circuits.
     W_QK = einsum(
         "layer head d_model1 d_head, layer head d_model2 d_head -> layer head d_model1 d_model2",
@@ -2050,13 +2050,13 @@ def get_qk_circuit(dt):
     return W_QK
 
 
-@st.cache_data
-def plot_svd_by_head_layer(dt, S):
-    d_head = dt.transformer_config.d_head
+@st.cache_data(experimental_allow_widgets=True)
+def plot_svd_by_head_layer(_dt, S):
+    d_head = _dt.transformer_config.d_head
     labels = [
         f"L{i}H{j}"
-        for i in range(0, dt.transformer_config.n_layers)
-        for j in range(dt.transformer_config.n_heads)
+        for i in range(0, _dt.transformer_config.n_layers)
+        for j in range(_dt.transformer_config.n_heads)
     ]
     S = einops.rearrange(S, "l h s -> (l h) s")
 
@@ -2072,22 +2072,22 @@ def plot_svd_by_head_layer(dt, S):
     st.plotly_chart(fig, use_container_width=True)
 
 
-@st.cache_data
-def layer_head_k_selector_ui(dt, key=""):
-    n_actions = dt.action_predictor.weight.shape[0]
+@st.cache_data(experimental_allow_widgets=True)
+def layer_head_k_selector_ui(_dt, key=""):
+    n_actions = _dt.action_predictor.weight.shape[0]
     layer_selection, head_selection, k_selection, d_selection = st.columns(4)
 
     with layer_selection:
         layer = st.selectbox(
             "Select Layer",
-            options=list(range(dt.transformer_config.n_layers)),
+            options=list(range(_dt.transformer_config.n_layers)),
             key="layer" + key,
         )
 
     with head_selection:
         head = st.selectbox(
             "Select Head",
-            options=list(range(dt.transformer_config.n_heads)),
+            options=list(range(_dt.transformer_config.n_heads)),
             key="head" + key,
         )
     with k_selection:
@@ -2103,11 +2103,11 @@ def layer_head_k_selector_ui(dt, key=""):
         else:
             k = 3
     with d_selection:
-        if dt.transformer_config.d_model > 3:
+        if _dt.transformer_config.d_model > 3:
             dims = st.slider(
                 "Select Dimensions",
                 min_value=3,
-                max_value=dt.transformer_config.d_head,
+                max_value=_dt.transformer_config.d_head,
                 value=3,
                 step=1,
                 key="dims" + key,
@@ -2118,8 +2118,8 @@ def layer_head_k_selector_ui(dt, key=""):
     return layer, head, k, dims
 
 
-@st.cache_data
-def embedding_matrix_selection_ui(dt):
+@st.cache_data(experimental_allow_widgets=True)
+def embedding_matrix_selection_ui(_dt):
     embedding_matrix_selection = st.columns(2)
     with embedding_matrix_selection[0]:
         embedding_matrix_1 = st.selectbox(
@@ -2134,9 +2134,9 @@ def embedding_matrix_selection_ui(dt):
             key=uuid.uuid4(),
         )
 
-    W_E_state = dt.state_embedding.weight
-    W_E_action = dt.action_embedding[0].weight
-    W_E_rtg = dt.reward_embedding[0].weight
+    W_E_state = _dt.state_embedding.weight
+    W_E_action = _dt.action_embedding[0].weight
+    W_E_rtg = _dt.reward_embedding[0].weight
 
     if embedding_matrix_1 == "State":
         embedding_matrix_1 = W_E_state
@@ -2155,10 +2155,10 @@ def embedding_matrix_selection_ui(dt):
     return embedding_matrix_1, embedding_matrix_2
 
 
-@st.cache_data
-def layer_head_channel_selector(dt, key=""):
-    n_heads = dt.transformer_config.n_heads
-    height, width, channels = dt.environment_config.observation_space[
+@st.cache_data(experimental_allow_widgets=True)
+def layer_head_channel_selector(_dt, key=""):
+    n_heads = _dt.transformer_config.n_heads
+    height, width, channels = _dt.environment_config.observation_space[
         "image"
     ].shape
     layer_selection, head_selection, other_selection = st.columns(3)
@@ -2166,7 +2166,7 @@ def layer_head_channel_selector(dt, key=""):
     with layer_selection:
         layer = st.selectbox(
             "Select Layer",
-            options=list(range(dt.transformer_config.n_layers)),
+            options=list(range(_dt.transformer_config.n_layers)),
             key="layer" + key,
         )
 


### PR DESCRIPTION
Changed some old analysis functions to better fit the displays.
Changed the display order to be the same as the analysis order on the left.
Upgraded to Streamlit 1.18.
Added caching to all static analyses except dimensionality reduction and qk circuit.

Note: static_analysis_component changes are mostly changing dt to _dt, since dt can't be cached and _varname tells Streamlit not to try. They can be skimmed.

Unit and acceptance tests are working and the static analyses look good but I haven't examined everything or all the other analyses - if necessary I can move back to Streamlit 1.16 and uncache things if things go wrong. I suspect this is relatively unlikely but I can't be sure. I did find one issue that Streamlit 1.18 caused by depreciating an old st.cache keyword argument, but it was a runtime error in the app that threw an error immediately, so it was easily spotted. This bodes well, I think - a problem that did occur was easily noticable.