### PR TITLE
Added ability to select by one or more states to Embeddings tab.

### DIFF
--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -257,10 +257,21 @@ def show_embeddings(dt):
                     pca_df["Channel"] = pca_df["State"].apply(
                         lambda x: x.split(",")[0]
                     )
+                
+                st.text('Inputs are of the form: "channel,(x,y)" and separated by | characters.')
+                user_input = st.text_input("Enter one or more states:", "")
+
+                # Ugly, ugly workaround for Streamlit not accepting spaces. So, channel,(x,y) becomes channel, (x,y) as desired.
+                states_to_filter = [state.replace('(', ' (') for state in user_input.split('|')]
+
+                if user_input:  # If the user has entered something
+                    pca_df_filtered = pca_df[pca_df['State'].isin(states_to_filter)]
+                else:
+                    pca_df_filtered = pca_df
 
                 # Create the plot
                 fig = px.scatter(
-                    pca_df,
+                    pca_df_filtered,
                     x="PC1",
                     y="PC2",
                     title="PCA on Embeddings",

--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -258,13 +258,14 @@ def show_embeddings(dt):
                         lambda x: x.split(",")[0]
                     )
                 
-                st.text('Inputs are of the form: "channel,(x,y)" and separated by | characters.')
-                user_input = st.text_input("Enter one or more states:", "")
+                states = set(pca_df['State'].values)
+                selected_channels = st.multiselect(
+                    "Select Observation Channels",
+                    options=list(states),
+                )
 
-                # Ugly, ugly workaround for Streamlit not accepting spaces. So, channel,(x,y) becomes channel, (x,y) as desired.
-                states_to_filter = [state.replace('(', ' (') for state in user_input.split('|')]
-
-                if user_input:  # If the user has entered something
+                states_to_filter = [state for state in selected_channels]
+                if states_to_filter:
                     pca_df_filtered = pca_df[pca_df['State'].isin(states_to_filter)]
                 else:
                     pca_df_filtered = pca_df


### PR DESCRIPTION
The actual formatting is pretty ugly, since Streamlit doesn't like spaces (Neither st.text_area nor st.text_input accepted them for me), and separation by commas doesn't work well when the format "channel, (x, y)" has commas. We could use regex but that raises further problems. So instead I decided on the format:

"channel,(x,y)|channel2,(a,b)|channel3,(c,d)" which I am...not super pleased with, but does work. And at least | means "or", which devs will understand.

Open to better ideas here.

![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/83a65a8d-aef7-4177-aa65-0e2c3772146d)