### PR TITLE
Fixed tuple error in path patching

### DIFF
--- a/src/streamlit_app/causal_analysis_components.py
+++ b/src/streamlit_app/causal_analysis_components.py
@@ -1254,7 +1254,8 @@ def show_path_patching(dt, logit_dir, clean_cache):
     with st.expander("Path Patching"):
         # 1. Create a corrupted forward pass using the same essential logic as activation
         # patching.
-        corrupted_tokens = get_corrupted_tokens_component(dt, key="path_")
+        corrupted_tokens, patch_type = get_corrupted_tokens_component(dt, key="path_")
+
         (
             corrupt_preds,
             corrupt_x,


### PR DESCRIPTION
Fixed "tuple.shape" error in path patching, so we can do path patching again! 
![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/aab364d7-2cd4-4806-ab4f-fbb7e09bdd23)
