### PR TITLE
changed error in path patching for same tokens to warning

### DIFF
--- a/src/streamlit_app/causal_analysis_components.py
+++ b/src/streamlit_app/causal_analysis_components.py
@@ -569,9 +569,8 @@ def get_corrupted_tokens_component(dt, key=""):
                 fig = px.imshow(image, animation_frame=0)
                 st.plotly_chart(fig, use_container_width=True)
 
-    assert not torch.all(
-        corrupted_tokens == previous_tokens
-    ), "corrupted tokens are the same!"
+    if torch.all(corrupted_tokens == previous_tokens):
+        st.warning("Corrupted tokens are the same as previous tokens. Please make a change to the environment.")
 
     return corrupted_tokens, noise_or_denoise
 


### PR DESCRIPTION
Hey, working with Jay. We just wanted to change that error in the path patching to be a warning instead. Makes it nicer since we should expect that before any patches are applied (or if the patches don't actually make a change to the environment). 

![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/3b786aa8-c867-43e7-ae0b-ca4cdb30e89d)
