### PR TITLE
Fixed error with recent gridmaps

### DIFF
--- a/src/streamlit_app/static_analysis/gridmaps.py
+++ b/src/streamlit_app/static_analysis/gridmaps.py
@@ -149,8 +149,7 @@ def neuron_projection_gridmap_component(activations, key="neuron projection"):
                 with columns[j]:
                     # given some specific head, I want to project onto some channels.
                     fig = plot_gridmap_from_embedding_congruence(
-                        activations[activations.Neuron == neurons[i]],
-                        channels[j],
+                        activations[(activations.Neuron == neurons[i]) & (activations.Channel == channels[j])],
                         abs_col_max=abs_col_max,
                     )
                     st.plotly_chart(fig, use_container_width=True)
@@ -189,8 +188,7 @@ def svd_projection_gridmap_component(activations, key="embeddings"):
                 with columns[j]:
                     # given some specific head, I want to project onto some channels.
                     fig = plot_gridmap_from_embedding_congruence(
-                        activations[activations.Direction == directions[i]],
-                        channels[j],
+                        activations[(activations.Direction == directions[i]) & (activations.Channel == channels[j])],
                         abs_col_max=abs_col_max,
                     )
                     st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
Fixed an error where abs_col_max was being passed as both a default and a keyword argument.

Before:
![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/c3948e9b-413b-4b73-9c8a-ceb79ea8fdb4)


After: 
![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/012d9778-a221-4074-9f96-f960c8112abb)
