### PR TITLE
Changing the default of Positive Action Direction from Forward to Left

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,7 +114,7 @@ with st.sidebar:
         positive_action_direction = st.selectbox(
             "Positive Action Direction",
             ["left", "right", "forward", "pickup", "drop", "toggle", "done"],
-            index=2,
+            index=0,
         )
         negative_action_direction = st.selectbox(
             "Negative Action Direction",


### PR DESCRIPTION
Hi Joseph, I'm James (working with Jay). 
From Jay's suggestion, I changed the default choice in the Positive Action Direction drop down from Forward to Left. 
| Before | After | 
| -------- | -------- | 
| ![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/aea15439-6111-49df-af75-63fbbf064697)   | ![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/ee9da0aa-cec0-4522-a0ce-72d156831759)  | 





