### PR TITLE
Initial RTG slider change and minor others

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,7 +114,7 @@ with st.sidebar:
         positive_action_direction = st.selectbox(
             "Positive Action Direction",
             ["left", "right", "forward", "pickup", "drop", "toggle", "done"],
-            index=2,
+            index=0,
         )
         negative_action_direction = st.selectbox(
             "Negative Action Direction",

--- a/src/streamlit_app/components.py
+++ b/src/streamlit_app/components.py
@@ -37,7 +37,7 @@ def hyperpar_side_bar():
         st.subheader("Hyperparameters")
         initial_rtg = st.slider(
             "Initial RTG",
-            min_value=-1.0,
+            min_value=0.0,
             max_value=1.0,
             value=0.9,
             step=0.01,
@@ -170,7 +170,7 @@ def decomp_configuration_ui(key=""):
     with cola:
         decomp_level = st.selectbox(
             "Decomposition Level",
-            ["Reduced", "Full", "MLP"],
+            ["Full", "MLP"],
             key=key + "decomp_level",
         )
     with colb:

--- a/src/streamlit_app/dynamic_analysis_components.py
+++ b/src/streamlit_app/dynamic_analysis_components.py
@@ -792,7 +792,7 @@ def rtg_scan_configuration_ui(dt):
             "RTG Range",
             min_value=min_value,
             max_value=max_value,
-            value=(-1, 1),
+            value=(0, 1),
             step=1,
         )
         min_rtg = rtg_range[0]


### PR DESCRIPTION
Heya Joe, working with Jay.
Is asked me to make three minor changes.
1. Change the slider on the left hand task bar to have an Initial RTG level range from 0 to 1 instead of -1 to 1.

| Before | After |
|-----|-----| 
| ![Screenshot 2023-10-03 120635](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/29db08bb-86c9-4f73-8696-96a0f03bdea3) | ![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/940b083d-113b-4df9-848f-368ce629cb8e) |

2. Under the Dynamic Analysis "RTG Scan". I changed the default RTG range to be 0 to 1 instead of -1 to 1

| Before | After |
|-----|-----| 
|![Screenshot 2023-10-03 121432](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/4eb74d3c-df66-4ef3-a602-cbafaa63966e)| ![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/1bbe536c-d3fb-46d2-86be-5e083d448e49)|

3. Under the Dynamic Analysis "RTG Scan". I removed the option to look at Reduced Decomposition level (idk why, Jay said it was a good idea). 

| Before | After |
|-----|-----| 
|![Screenshot 2023-10-03 122548](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/e2a24c15-32fc-4573-bbfb-2c09239b3c76)|![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/113799901/af607786-54a4-4d6f-8cec-e514db038b12)|

