### PR TITLE
Added light mode friendly checkbox to Embeddings for PCA graphs

### DIFF
--- a/src/streamlit_app/static_analysis/pca.py
+++ b/src/streamlit_app/static_analysis/pca.py
@@ -37,7 +37,7 @@ def get_pca(data, labels, n_components=None):
     return pca_df, percent_variance, loadings, fitted_pca
 
 
-def get_2d_scatter_plot(pca_df, percent_variance):
+def get_2d_scatter_plot(pca_df, percent_variance, light_mode):
     # Create the plot
     fig = px.scatter(
         pca_df,
@@ -66,7 +66,7 @@ def get_2d_scatter_plot(pca_df, percent_variance):
             y0=0,
             x1=row["PC1"],
             y1=row["PC2"],
-            line=dict(color="white", width=2),
+            line=dict(color="black" if light_mode else "white", width=2),
         )
 
     # increase font size
@@ -81,7 +81,7 @@ def get_2d_scatter_plot(pca_df, percent_variance):
     return fig
 
 
-def get_3d_scatter_plot(pca_df, percent_variance):
+def get_3d_scatter_plot(pca_df, percent_variance, light_mode):
     fig = px.scatter_3d(
         pca_df,
         x="PC1",
@@ -107,7 +107,7 @@ def get_3d_scatter_plot(pca_df, percent_variance):
             y=[0, row["PC2"]],
             z=[0, row["PC3"]],
             mode="lines",
-            line=dict(color="RoyalBlue", width=3),
+            line=dict(color="black" if light_mode else "white", width=3),
             # remove from legend
             showlegend=False,
             # remove hover

--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -109,6 +109,7 @@ def show_embeddings(_dt, cache):
                 format_func=lambda x: STATE_EMBEDDING_LABELS[x],
                 default=[263, 312, 258, 307],
             )
+            light_mode_friendly = st.checkbox("Make graphs Light Mode friendly")
 
         with b:
             cluster = st.checkbox("Cluster")
@@ -161,11 +162,11 @@ def show_embeddings(_dt, cache):
             ) = st.tabs(["2D-Scatter", "3D-Scatter", "Scree Plot", "Loadings"])
 
             with scatter_2d_tab:
-                fig = get_2d_scatter_plot(pca_df, percent_variance)
+                fig = get_2d_scatter_plot(pca_df, percent_variance, light_mode_friendly)
                 st.plotly_chart(fig, use_container_width=True)
 
             with scatter_3d_tab:
-                fig = get_3d_scatter_plot(pca_df, percent_variance)
+                fig = get_3d_scatter_plot(pca_df, percent_variance, light_mode_friendly)
                 st.plotly_chart(fig, use_container_width=True)
 
             with scree_plot_tab:


### PR DESCRIPTION
![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/0db889ee-d632-40f1-ad3d-37e771680080)

![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/0d0cc508-ed99-4519-b96a-768a093d19f8)

Works for 2D and 3D graphs.
