### PR TITLE
Added attention pattern and logit lens analyses for patched activations

### DIFF
--- a/app.py
+++ b/app.py
@@ -210,13 +210,15 @@ if "Composition Scores" in analyses:
 if "RTG Scan" in analyses:
     show_rtg_scan(dt, logit_dir=logit_dir)
 if "Logit Lens" in analyses:
-    show_logit_lens(dt, cache, logit_dir=logit_dir)
+    with st.expander("Show Logit Lens"):
+        show_logit_lens(dt, cache, logit_dir=logit_dir)
 if "Neuron Activation Analysis" in analyses:
     show_neuron_activation_decomposition(dt, cache, logit_dir)
 if "Projection Analysis" in analyses:
     show_residual_stream_projection_onto_component(dt, cache, logit_dir)
 if "Attention Pattern" in analyses:
-    show_attention_pattern(dt, cache)
+    with st.expander("Attention Pattern at at current Reward-to-Go"):
+        show_attention_pattern(dt, cache)
 if "Observation View" in analyses:
     show_observation_view(dt, tokens, logit_dir)
 if "Cache" in analyses:  # Not yet implemented.

--- a/src/streamlit_app/causal_analysis_components.py
+++ b/src/streamlit_app/causal_analysis_components.py
@@ -23,6 +23,10 @@ from .visualizations import plot_logit_scan
 
 from .analysis import get_residual_decomp
 from .constants import IDX_TO_ACTION, IDX_TO_OBJECT
+from .dynamic_analysis_components import (
+    show_logit_lens,
+    show_rtg_scan,
+)
 from .environment import (
     get_action_preds_from_app_state,
     get_action_preds_from_tokens,
@@ -416,6 +420,16 @@ def show_activation_patching(dt, logit_dir, original_cache):
                 kwargs,
                 apply_metric_to_cache=True,
             )
+        
+        if st.checkbox(
+            "Analyse corrupted pass (slightly expensive)", key="corrupted-checkbox"
+        ):
+            corrupt_rtg_scan_tab, corrupt_logit_lens_tab = st.tabs(["RTG Scan", "Logit Lens"])
+            with corrupt_rtg_scan_tab:
+                show_rtg_scan(dt, logit_dir=logit_dir)
+            with corrupt_logit_lens_tab:
+                show_logit_lens(dt, corrupt_cache, logit_dir=logit_dir)
+            
 
 
 def get_corrupted_tokens_component(dt, key=""):

--- a/src/streamlit_app/causal_analysis_components.py
+++ b/src/streamlit_app/causal_analysis_components.py
@@ -1290,12 +1290,12 @@ def show_path_patching(dt, logit_dir, clean_cache):
         if st.checkbox("show corrupted action predictions", key="path"):
             plot_action_preds(corrupt_preds)
 
-        if st.checkbox("Show corrupted analyses (expensive)", key="corrupt_analysis_path"):
+        if st.checkbox("Show corrupted analyses (slightly expensive)", key="corrupt_analysis_path"):
             corrupt_attention_pattern_tab, corrupt_logit_lens_tab = st.tabs(["Attention Pattern", "Logit Lens"])
             with corrupt_attention_pattern_tab:
-                show_attention_pattern(dt, corrupted_cache)
+                show_attention_pattern(dt, corrupted_cache, key="corrupt-path-")
             with corrupt_logit_lens_tab:
-                show_logit_lens(dt, corrupted_cache)
+                show_logit_lens(dt, corrupted_cache, logit_dir, key="corrupt-path-")
 
         # rewrite previous line but with nicer formatting
         st.write(

--- a/src/streamlit_app/causal_analysis_components.py
+++ b/src/streamlit_app/causal_analysis_components.py
@@ -24,8 +24,8 @@ from .visualizations import plot_logit_scan
 from .analysis import get_residual_decomp
 from .constants import IDX_TO_ACTION, IDX_TO_OBJECT
 from .dynamic_analysis_components import (
+    show_attention_pattern,
     show_logit_lens,
-    show_rtg_scan,
 )
 from .environment import (
     get_action_preds_from_app_state,
@@ -328,6 +328,13 @@ def show_activation_patching(dt, logit_dir, original_cache):
         if st.checkbox("show corrupted action predictions"):
             plot_action_preds(corrupt_preds)
 
+        if st.checkbox("Show corrupted analyses (slightly expensive)", key="corrupt_analysis"):
+            corrupt_attention_pattern_tab, corrupt_logit_lens_tab = st.tabs(["Attention Pattern", "Logit Lens"])
+            with corrupt_attention_pattern_tab:
+                show_attention_pattern(dt, corrupt_cache, key="corrupt-")
+            with corrupt_logit_lens_tab:
+                show_logit_lens(dt, corrupt_cache, logit_dir, key="corrupt-")
+
         clean_logit_dif = clean_x[0, -1] @ logit_dir
         corrupted_logit_dif = corrupt_x[0, -1] @ logit_dir
 
@@ -420,18 +427,8 @@ def show_activation_patching(dt, logit_dir, original_cache):
                 kwargs,
                 apply_metric_to_cache=True,
             )
-        
-        if st.checkbox(
-            "Analyse corrupted pass (slightly expensive)", key="corrupted-checkbox"
-        ):
-            corrupt_rtg_scan_tab, corrupt_logit_lens_tab = st.tabs(["RTG Scan", "Logit Lens"])
-            with corrupt_rtg_scan_tab:
-                show_rtg_scan(dt, logit_dir=logit_dir)
-            with corrupt_logit_lens_tab:
-                show_logit_lens(dt, corrupt_cache, logit_dir=logit_dir)
-            
 
-
+      
 def get_corrupted_tokens_component(dt, key=""):
     a, b, c = st.columns(3)
     with a:
@@ -1292,6 +1289,13 @@ def show_path_patching(dt, logit_dir, clean_cache):
 
         if st.checkbox("show corrupted action predictions", key="path"):
             plot_action_preds(corrupt_preds)
+
+        if st.checkbox("Show corrupted analyses (expensive)", key="corrupt_analysis_path"):
+            corrupt_attention_pattern_tab, corrupt_logit_lens_tab = st.tabs(["Attention Pattern", "Logit Lens"])
+            with corrupt_attention_pattern_tab:
+                show_attention_pattern(dt, corrupted_cache)
+            with corrupt_logit_lens_tab:
+                show_logit_lens(dt, corrupted_cache)
 
         # rewrite previous line but with nicer formatting
         st.write(

--- a/src/streamlit_app/visualizations.py
+++ b/src/streamlit_app/visualizations.py
@@ -69,6 +69,7 @@ def plot_attention_pattern_single(
     specific_heads: List = None,
     method="Plotly",
     scale_by_value=False,
+    key="",
 ):
     labels = st.session_state.labels
 
@@ -126,7 +127,7 @@ def plot_attention_pattern_single(
                 fig.update_xaxes(ticktext=labels)
                 fig.update_yaxes(ticktext=labels)
 
-                st.plotly_chart(fig, use_container_width=True)
+                st.plotly_chart(fig, use_container_width=True, key=key + "attention-pattern")
 
         return
 


### PR DESCRIPTION
![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/3ce26d4e-1658-47ae-b334-b1ddd83fdc8b)

Performed:

- Added attention pattern and logit lens analyses for corrupt cache in both activation patching and path patching.

- Had to move st.extenders for attention patterns and logit lens to the app.py level because you can't have extenders within extenders, which would have happened with activation patching -> logit lens (as an example) otherwise. This does not affect the behaviour of the UI that I can detect.

- The big changes in dynamic analyses can be largely ignored - those are just removing the st.extender items from it, and altering the indentation level of everything that's left, plus adding some keys.

Tested:

- Made sure that the analyses from clean and corrupted were different.
- Made sure no Streamlit errors were caused by having the clean analysis, corrupt activation analysis, and corrupt path analysis all open at once in Streamlit.