### PR TITLE
Added text to cosine embedding heatmap of size 10 or less. Increased font size.

### DIFF
--- a/src/streamlit_app/static_analysis/gridmaps.py
+++ b/src/streamlit_app/static_analysis/gridmaps.py
@@ -229,7 +229,7 @@ def plot_gridmap_from_embedding_congruence(
                     showarrow=False,
                     font=dict(
                         family="Courier New, monospace",
-                        size=12,
+                        size=14,
                         color="black"
                     ),
                 )

--- a/src/streamlit_app/static_analysis_components.py
+++ b/src/streamlit_app/static_analysis_components.py
@@ -149,6 +149,7 @@ def show_embeddings(_dt, cache):
                 color_continuous_midpoint=0,
                 cluster=cluster,
                 show_labels=df.shape[0] < 20,
+                max_labels=10,
             )
             st.plotly_chart(fig, use_container_width=True)
 

--- a/src/streamlit_app/visualizations.py
+++ b/src/streamlit_app/visualizations.py
@@ -235,6 +235,7 @@ def plot_heatmap(
     color_continuous_scale="RdBu",
     cluster=True,
     show_labels=True,
+    max_labels=0,
 ):
     # Convert dataframe to numpy array
     data_array = df.to_numpy()
@@ -249,6 +250,7 @@ def plot_heatmap(
         df = df.iloc[reordered_ind, reordered_ind]
         data_array = df.to_numpy()
 
+    print(data_array.shape)
     fig = px.imshow(
         df,
         color_continuous_midpoint=color_continuous_midpoint,
@@ -283,6 +285,21 @@ def plot_heatmap(
         fig.update_yaxes(
             visible=False,
         )
+
+    if max_labels >= data_array.shape[0]:
+        for i in range(data_array.shape[0]):
+            for j in range(data_array.shape[0]):
+                fig.add_annotation(
+                    x=j,
+                    y=i,
+                    text=str(round(data_array[i][j].item(), 2)),
+                    showarrow=False,
+                    font=dict(
+                        family="Courier New, monospace",
+                        size=14,
+                        color="white" if data_array[i][j].item() > 0.5 else "black"
+                    ),
+                )
 
     return fig
 

--- a/src/streamlit_app/visualizations.py
+++ b/src/streamlit_app/visualizations.py
@@ -250,7 +250,6 @@ def plot_heatmap(
         df = df.iloc[reordered_ind, reordered_ind]
         data_array = df.to_numpy()
 
-    print(data_array.shape)
     fig = px.imshow(
         df,
         color_continuous_midpoint=color_continuous_midpoint,


### PR DESCRIPTION
Size 10: ![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/aedccac0-e0b7-4bb3-b4f1-f420c1611aa0)
Size 11: ![image](https://github.com/jbloomAus/DecisionTransformerInterpretability/assets/75793813/159b5ee0-c72e-4073-a618-9a6508b086a2)

I set it to white text if value > 0.5 because black on dark blue is hard to see, but white on light blue is even worse. So we use white for dark blue and black for everything else. Not consistent design but being able to see numbers is more important and we can't do that with just black or white, and colored text would be much more inconsistent with other graphs.