### PR TITLE
Swapped device to str instead of torch.device to fix PyArrow crash problem

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -59,8 +59,8 @@ class EnvironmentConfig:
         self.observation_space = (
             self.observation_space or env.observation_space
         )
-        if isinstance(self.device, str):
-            self.device = torch.device(self.device)
+        if isinstance(self.device, torch.device):
+            self.device = str(self.device)
 
 
 @dataclass
@@ -114,8 +114,8 @@ class TransformerModelConfig:
         )
 
         assert self.time_embedding_type in ["embedding", "linear"]
-        if isinstance(self.device, str):
-            self.device = torch.device(self.device)
+        if isinstance(self.device, torch.device):
+            self.device = str(self.device)
 
 
 @dataclass
@@ -163,8 +163,8 @@ class LSTMModelConfig:
         assert self.lang_model in ["gru", "bigru", "attgru"]
         # self.observation_space = self.environment_config.observation_space
         # self.action_space = self.environment_config.action_space
-        if isinstance(self.device, str):
-            self.device = torch.device(self.device)
+        if isinstance(self.device, torch.device):
+            self.device = str(self.device)
 
 
 @dataclass
@@ -199,8 +199,8 @@ class OfflineTrainConfig:
 
     def __post_init__(self):
         assert self.model_type in ["decision_transformer", "clone_transformer"]
-        if isinstance(self.device, str):
-            self.device = torch.device(self.device)
+        if isinstance(self.device, torch.device):
+            self.device = str(self.device)
 
 
 @dataclass
@@ -239,8 +239,8 @@ class OnlineTrainConfig:
                 "trajectories", str(uuid.uuid4()) + ".gz"
             )
 
-        if isinstance(self.device, str):
-            self.device = torch.device(self.device)
+        if isinstance(self.device, torch.device):
+            self.device = str(self.device)
 
 
 @dataclass
@@ -257,8 +257,8 @@ class RunConfig:
     wandb_entity: str = None
 
     def __post_init__(self):
-        if isinstance(self.device, str):
-            self.device = torch.device(self.device)
+        if isinstance(self.device, torch.device):
+            self.device = str(self.device)
 
 
 class ConfigJsonEncoder(json.JSONEncoder):
@@ -285,8 +285,8 @@ class ConfigJsonEncoder(json.JSONEncoder):
         # check if new config is a dataclass
         if dataclasses.is_dataclass(new_config):
             return dataclasses.asdict(new_config)
-        elif isinstance(new_config, torch.device):
-            return str(new_config)
+        if isinstance(new_config, torch.device):
+            self.device = str(new_config)
         elif isinstance(new_config, gym.spaces.Space):
             return None  # don't save observation space and action space if they are named other stuff
         else:

--- a/src/ppo/agent.py
+++ b/src/ppo/agent.py
@@ -212,7 +212,7 @@ class FCAgent(PPOAgent):
         """
 
         device = memory.device
-        cuda = device.type == "cuda"
+        cuda = device == "cuda"
         obs = memory.next_obs
         done = memory.next_done
 
@@ -407,9 +407,9 @@ class TransformerPPOAgent(PPOAgent):
         actions_timesteps = obs_timesteps - 1
         action_pad_token = self.actor.environment_config.action_space.n
         n_envs = envs.num_envs
-        if isinstance(device, str):
-            device = t.device(device)
-        cuda = device.type == "cuda"
+        if isinstance(device, t.device):
+            device = str(device)
+        cuda = device == "cuda"
 
         obss = t.zeros((n_envs, obs_timesteps, *obs.shape[1:]), device=device)
         acts = (
@@ -662,8 +662,8 @@ class LSTMPPOAgent(PPOAgent):
         sampling_method="basic",
         **kwargs,
     ) -> None:
-        device = memory.device
-        cuda = device.type == "cuda"
+        device = str(memory.device)
+        cuda = device == "cuda"
         obs = memory.next_obs
         done = memory.next_done
         self.recurrence_memory = t.zeros(

--- a/tests/acceptance/test_dt_train.py
+++ b/tests/acceptance/test_dt_train.py
@@ -79,7 +79,7 @@ def online_config():
         max_grad_norm=2,
         trajectory_path=None,
         fully_observed=False,
-        device=torch.device("cpu"),
+        device="cpu",
     )
 
     return online_config


### PR DESCRIPTION
Tests performed:

- All acceptance and unit tests
- Opened the app and tried some analyses. No weird occurrences and no PyArrow bugs occurred.

Caveat: Entirely possible that this may cause errors in places neither I nor the code tested. On the plus side, fixing it appears easy - there doesn't appear to be any reason I can determine why the device has to be torch.device. The _get_device_index util in PyTorch that is used in torch.device can take in a string just fine - it just internally parses it to a torch.device before doing its thing. Thus, if we run into further errors (e.g, maybe we want to train a new model later) we should easily be able to swap everything to strings without causing arcane BS to occur.

In short, I think it is better to make sure the code we are using atm works if any errors that occur later are obvious and easy to fix - any side-effects that may arise won't take much time to fix, and won't cause subtle issues we don't notice.

Docs: https://github.com/pytorch/pytorch/blob/main/torch/cuda/_utils.py - _get_device_index
https://pytorch.org/docs/stable/_modules/torch/cuda.html#device - torch.device
